### PR TITLE
Remove extern statements and standardise use statements

### DIFF
--- a/src/actors/jsonrpc_server.rs
+++ b/src/actors/jsonrpc_server.rs
@@ -2,11 +2,12 @@
 
 use async_std::task;
 use futures::FutureExt;
-use jsonrpc_http_server::jsonrpc_core::*;
-use jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBuilder};
-use serde_json::json;
-
+use jsonrpc_http_server::{
+    jsonrpc_core::*, AccessControlAllowOrigin, DomainsValidation, ServerBuilder,
+};
 use kuska_ssb::{api::dto::content::TypedMessage, feed::Message, keystore::OwnedIdentity};
+use log::{info, warn};
+use serde_json::json;
 
 use crate::{broker::*, error::Error, Result, KV_STORAGE};
 

--- a/src/actors/peer.rs
+++ b/src/actors/peer.rs
@@ -1,4 +1,3 @@
-use once_cell::sync::Lazy;
 use std::{collections::HashSet, time::Duration};
 
 use async_std::{
@@ -7,10 +6,7 @@ use async_std::{
     sync::{Arc, RwLock},
     task,
 };
-use futures::stream::StreamExt;
-
-use futures::{FutureExt, SinkExt};
-
+use futures::{pin_mut, select_biased, stream::StreamExt, FutureExt, SinkExt};
 use kuska_ssb::{
     api::ApiCaller,
     crypto::{ed25519, ToSsbId},
@@ -22,12 +18,16 @@ use kuska_ssb::{
     keystore::OwnedIdentity,
     rpc::{RpcReader, RpcWriter},
 };
+use log::{error, info, trace, warn};
+use once_cell::sync::Lazy;
 
-use crate::{broker::*, Result};
-
-use super::rpc::{
-    BlobsGetHandler, BlobsWantsHandler, GetHandler, HistoryStreamHandler, RpcHandler, RpcInput,
-    WhoAmIHandler,
+use crate::{
+    actors::rpc::{
+        BlobsGetHandler, BlobsWantsHandler, GetHandler, HistoryStreamHandler, RpcHandler, RpcInput,
+        WhoAmIHandler,
+    },
+    broker::*,
+    Result,
 };
 
 pub enum Connect {

--- a/src/actors/rpc/blobs_get.rs
+++ b/src/actors/rpc/blobs_get.rs
@@ -1,19 +1,24 @@
 #![allow(clippy::single_match)]
 
-use async_std::io::Write;
 use std::{
     collections::{HashMap, HashSet},
     marker::PhantomData,
 };
 
+use async_std::io::Write;
 use async_trait::async_trait;
 use kuska_ssb::{
     api::{dto, ApiCaller, ApiMethod},
     rpc,
 };
+use log::{info, trace, warn};
 
-use super::{RpcHandler, RpcInput};
-use crate::{broker::ChBrokerSend, storage::blob::ToBlobHashId, Result, BLOB_STORAGE};
+use crate::{
+    actors::rpc::handler::{RpcHandler, RpcInput},
+    broker::ChBrokerSend,
+    storage::blob::ToBlobHashId,
+    Result, BLOB_STORAGE,
+};
 
 pub enum RpcBlobsGetEvent {
     Get(dto::BlobsGetIn),

--- a/src/actors/rpc/blobs_wants.rs
+++ b/src/actors/rpc/blobs_wants.rs
@@ -1,23 +1,22 @@
 #![allow(clippy::single_match)]
 
-use async_std::io::Write;
 use std::{collections::HashMap, marker::PhantomData};
 
-use crate::futures::SinkExt;
+use async_std::io::Write;
 use async_trait::async_trait;
+use futures::SinkExt;
 use kuska_ssb::{
     api::{dto, ApiCaller, ApiMethod},
     rpc,
 };
+use log::{trace, warn};
 
 use crate::{
-    broker::ChBrokerSend,
+    actors::rpc::handler::{RpcHandler, RpcInput},
+    broker::{BrokerEvent, ChBrokerSend, Destination},
     storage::blob::{StoBlobEvent, ToBlobHashId},
     Result, BLOB_STORAGE,
 };
-
-use super::{RpcHandler, RpcInput};
-use crate::broker::{BrokerEvent, Destination};
 
 enum RpcBlobsWantsEvent {
     BroadcastWants(Vec<(String, i64)>),

--- a/src/actors/rpc/get.rs
+++ b/src/actors/rpc/get.rs
@@ -1,15 +1,17 @@
-use async_std::io::Write;
 use std::marker::PhantomData;
 
+use async_std::io::Write;
 use async_trait::async_trait;
 use kuska_ssb::{
     api::{ApiCaller, ApiMethod},
     rpc,
 };
 
-use crate::{broker::ChBrokerSend, Result, KV_STORAGE};
-
-use super::{RpcHandler, RpcInput};
+use crate::{
+    actors::rpc::handler::{RpcHandler, RpcInput},
+    broker::ChBrokerSend,
+    Result, KV_STORAGE,
+};
 
 pub struct GetHandler<W>
 where

--- a/src/actors/rpc/handler.rs
+++ b/src/actors/rpc/handler.rs
@@ -1,11 +1,11 @@
 use async_std::io::Write;
+use async_trait::async_trait;
+use kuska_ssb::{api::ApiCaller, rpc::RecvMsg};
 
 use crate::{
     broker::{BrokerMessage, ChBrokerSend},
     Result,
 };
-use async_trait::async_trait;
-use kuska_ssb::{api::ApiCaller, rpc::RecvMsg};
 
 #[derive(Debug)]
 pub enum RpcInput {

--- a/src/actors/rpc/history_stream.rs
+++ b/src/actors/rpc/history_stream.rs
@@ -1,20 +1,19 @@
 use std::{collections::HashMap, marker::PhantomData, string::ToString};
 
-use crate::futures::SinkExt;
 use async_std::io::Write;
 use async_trait::async_trait;
-use regex::Regex;
-
+use futures::SinkExt;
 use kuska_ssb::{
     api::{dto, ApiCaller, ApiMethod},
     feed::Message,
     rpc,
 };
-
+use log::{debug, info, warn};
 use once_cell::sync::Lazy;
+use regex::Regex;
 
-use super::{RpcHandler, RpcInput};
 use crate::{
+    actors::rpc::handler::{RpcHandler, RpcInput},
     broker::{BrokerEvent, ChBrokerSend, Destination},
     storage::kv::StoKvEvent,
     Result, BLOB_STORAGE, CONFIG, KV_STORAGE,

--- a/src/actors/rpc/whoami.rs
+++ b/src/actors/rpc/whoami.rs
@@ -2,14 +2,16 @@ use std::marker::PhantomData;
 
 use async_std::io::Write;
 use async_trait::async_trait;
-
 use kuska_ssb::{
     api::{ApiCaller, ApiMethod},
     rpc::RecvMsg,
 };
 
-use super::{RpcHandler, RpcInput};
-use crate::{broker::ChBrokerSend, Result};
+use crate::{
+    actors::rpc::handler::{RpcHandler, RpcInput},
+    broker::ChBrokerSend,
+    Result,
+};
 
 pub struct WhoAmIHandler<'a, W>
 where

--- a/src/actors/tcp_server.rs
+++ b/src/actors/tcp_server.rs
@@ -2,9 +2,7 @@ use async_std::{
     net::{TcpListener, ToSocketAddrs},
     prelude::*,
 };
-
-use futures::FutureExt;
-
+use futures::{select_biased, FutureExt};
 use kuska_ssb::keystore::OwnedIdentity;
 
 use crate::{broker::*, Result};

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -9,8 +9,9 @@ use async_std::{
 use core::any::Any;
 use futures::{
     channel::{mpsc, oneshot},
-    FutureExt, SinkExt,
+    select_biased, FutureExt, SinkExt,
 };
+use log::{info, trace};
 use once_cell::sync::Lazy;
 
 use crate::Result;

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use kuska_ssb::{
     crypto::{ToSodiumObject, ToSsbId},
     keystore::OwnedIdentity,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::Result;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,22 +1,16 @@
 #![recursion_limit = "256"]
 
-#[macro_use]
-extern crate futures;
-#[macro_use]
-extern crate log;
-extern crate procfs;
-extern crate sha2;
-extern crate slice_deque;
-#[macro_use]
-extern crate serde;
-extern crate toml;
+use std::{env, path::PathBuf};
 
-use async_std::{fs::File, io::ReadExt, prelude::*};
-
-use async_std::sync::{Arc, RwLock};
+use async_std::{
+    fs::File,
+    io::ReadExt,
+    prelude::*,
+    sync::{Arc, RwLock},
+};
+use log::debug;
 use once_cell::sync::{Lazy, OnceCell};
 use sled::Config as KvConfig;
-use std::{env, path::PathBuf};
 use structopt::StructOpt;
 
 // Generate a command line parser.

--- a/src/storage/blob.rs
+++ b/src/storage/blob.rs
@@ -1,5 +1,3 @@
-use crate::broker::{BrokerEvent, ChBrokerSend, Destination};
-use sha2::{Digest, Sha256};
 use std::{
     fs::File,
     io::{Read, Result, Write},
@@ -7,6 +5,9 @@ use std::{
 };
 
 use futures::SinkExt;
+use sha2::{Digest, Sha256};
+
+use crate::broker::{BrokerEvent, ChBrokerSend, Destination};
 
 pub enum StoBlobEvent {
     Added(String),

--- a/src/storage/kv.rs
+++ b/src/storage/kv.rs
@@ -1,8 +1,8 @@
 use futures::SinkExt;
+use kuska_ssb::feed::{Feed, Message};
 use serde::{Deserialize, Serialize};
 
 use crate::broker::{BrokerEvent, ChBrokerSend, Destination};
-use kuska_ssb::feed::{Feed, Message};
 
 const PREFIX_LASTFEED: u8 = 0u8;
 const PREFIX_FEED: u8 = 1u8;


### PR DESCRIPTION
No change in functionality; just some gardening.

- Remove all `extern` statements from `src/main.rs`
  - Replace them with `use` statements where required
- Group `use` statements under the root dependency
- Organise `use` statements in the following order
  - `std::`
  - All external dependencies (in alphabetical order)
  - `crate::` 