### PR TITLE
Split config file and rename "friends" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,12 @@ cd solar
 cargo build --release
 ```
 
-Add friend(s) to `solar.toml` (public key(s) of feeds you wish to replicate):
+Add peer(s) to `replication.toml` (public key(s) of feeds you wish to replicate):
 
 ```
-vim ~/.local/share/solar/solar.toml
+vim ~/.local/share/solar/replication.toml
 
-id = "@...=.ed25519"
-secret "...==.ed25519"
-friends = ["@...=.ed25519"]
+peers = ["@...=.ed25519"]
 ```
 
 Run solar with LAN discovery enabled:
@@ -39,6 +37,10 @@ Run solar with LAN discovery enabled:
 ```
 ./target/release/solar --lan true
 ```
+
+_Note: a new public-private keypair will be generated and saved to
+`~/.local/share/solar/secret.toml` (or in the equivalent directory on your
+operating system)._
 
 ## Core Features
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,36 +6,67 @@ use serde::{Deserialize, Serialize};
 
 use crate::Result;
 
+/// Public-private keypair.
 #[derive(Serialize, Deserialize)]
-pub struct Config {
+pub struct SecretConfig {
+    /// Public key.
     pub id: String,
+    /// Private key.
     pub secret: String,
-    pub friends: Vec<String>,
 }
 
-impl Config {
+impl SecretConfig {
+    /// Generate a new, unique public-private keypair.
     pub fn create() -> Self {
         let OwnedIdentity { id, sk, .. } = OwnedIdentity::create();
-        Config {
+
+        SecretConfig {
             id,
             secret: sk.to_ssb_id(),
-            friends: Vec::new(),
         }
     }
 
+    /// Serialize an instance of `SecretConfig` as a TOML byte vector.
     pub fn to_toml(&self) -> Result<Vec<u8>> {
         Ok(toml::to_vec(&self)?)
     }
 
+    /// Deserialize a TOML byte slice into an instance of `SecretConfig`.
     pub fn from_toml(s: &[u8]) -> Result<Self> {
-        Ok(toml::from_slice::<Config>(s)?)
+        Ok(toml::from_slice::<SecretConfig>(s)?)
     }
 
+    /// Generate an `OwnedIdentity` from the public-private keypair.
     pub fn owned_identity(&self) -> Result<OwnedIdentity> {
         Ok(OwnedIdentity {
             id: self.id.clone(),
             pk: self.id[1..].to_ed25519_pk()?,
             sk: self.secret.to_ed25519_sk()?,
         })
+    }
+}
+
+/// List of peers whose data will be replicated.
+#[derive(Serialize, Deserialize)]
+pub struct ReplicationConfig {
+    /// Public keys.
+    pub peers: Vec<String>,
+}
+
+impl ReplicationConfig {
+    /// Generate a new instance.
+    // TODO: consider replacing this with a `Default` derivation
+    pub fn create() -> Self {
+        ReplicationConfig { peers: Vec::new() }
+    }
+
+    /// Serialize an instance of `ReplicationConfig` as a TOML byte vector.
+    pub fn to_toml(&self) -> Result<Vec<u8>> {
+        Ok(toml::to_vec(&self)?)
+    }
+
+    /// Deserialize a TOML byte slice into an instance of `ReplicationConfig`.
+    pub fn from_toml(s: &[u8]) -> Result<Self> {
+        Ok(toml::from_slice::<ReplicationConfig>(s)?)
     }
 }


### PR DESCRIPTION
🚨  **BREAKING CHANGES INTRODUCED** 🚨 

This PR takes the existing solar config file (`solar.toml`) and splits it into two files. One for the public-private keypair (`secret.toml`) and one for replication configuration (`replication.toml`).

This separation of concerns is in keeping with Scuttlebutt tradition. It also means that replication configuration can be shared without risk of exposing the public-private keypair.

The replication configuration file currently only contains a list of public keys of peers who should be replication. In the future it may hold additional replication settings.

I have also taken this opportunity to rename the `friends` CLI option to `replicate`. "Friends" has a very specific meaning in the context of Scuttlebutt (a mutual follow) and I don't want to cause confusion by overloading the term. In the updated API, an operator submits a list of peers they wish to replicate using the `replicate` option.