### PR TITLE
Query peers in db

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ operating system)._
 
 ## Extensions
 
-_Undergoing active development._
+_Undergoing active development. Expect APIs to change._
 
 - [X] json-rpc server for user queries
   - [X] ping
   - [X] whoami
   - [X] publish
+  - [X] get_peers
   - [ ] ...
 - [ ] improved connection handler
 - [ ] ebt replication
@@ -85,6 +86,7 @@ The server currently supports HTTP.
 | `ping` | | `pong!` | Responds if the JSON-RPC server is running |
 | `whoami` | | `<@...=.ed25519>` | Returns the public key of the local node |
 | `publish` | `<content>` | `{ "msg_ref": "<%...=.sha256>", "seq": <int> }` | Publishes a message and returns the reference (message hash) and sequence number |
+| `get_peers` | | `[{ "id": "<@...=.ed25519>", "sequence": <int> }` | Return the public key and latest sequence number for all peers in the local database |
 
 `curl` can be used to invoke the available methods from the commandline:
 


### PR DESCRIPTION
Adds the ability to store and query the public key and latest sequence number of all feeds in the local database. I think this will be really useful for testing replication. Basically corresponds to the `replicate.upto` MUXRPC method in go-ssb.

- Adds a peer prefix
- Adds kv store methods
  - `peer_key`
  - `set_peer`
  - `get_peers`
- Adds a JSON-RPC method
  - `get_peers`

I'm not too sure about the `get_peers` naming. Might change it later as the API grows.

Example JSON-RPC response (pretty printed):

```
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": [
        {
            "id": "@4+aQ4kCvSvghIq2yTh6LPz0ELZ3x4CKd93JTwkoudPM=.ed25519",
            "sequence": 48
        },
        {
            "id": "@HEqy940T6uB+T+d9Jaa58aNfRzLx9eRWqkZljBmnkmk=.ed25519",
            "sequence": 25179
        },
        {
            "id": "@MDErHCTxklXc7QZ43fnyzERbRJ7fccRfCYF11EqIFEI=.ed25519",
            "sequence": 3
        },
        {
            "id": "@o8lWpyLeSqV/BJV9pbxFhKpwm6Lw5k+sqexYK+zT9Tc=.ed25519",
            "sequence": 5
        }
    ]
}
```