### PR TITLE
Refactor KV store

### DIFF
--- a/src/actors/jsonrpc_server.rs
+++ b/src/actors/jsonrpc_server.rs
@@ -61,7 +61,7 @@ pub async fn actor(server_id: OwnedIdentity, port: u16) -> Result<()> {
             // Lookup the last message published on the local feed.
             // Return `None` if no messages have yet been published on the feed.
             let last_msg = db
-                .get_last_message(&server_id.id)
+                .get_latest_msg_val(&server_id.id)
                 // Map the error to a variant of our crate-specific error type.
                 // The `?` operator then performs the `From` conversion to
                 // the `jsonrpc_core::Error` type if an error occurs.

--- a/src/actors/rpc/get.rs
+++ b/src/actors/rpc/get.rs
@@ -70,8 +70,8 @@ where
     ) -> Result<bool> {
         let args: Vec<String> = serde_json::from_value(req.args.clone())?;
 
-        let msg = KV_STORAGE.read().await.get_message(&args[0]);
-        match msg {
+        let msg_val = KV_STORAGE.read().await.get_msg_val(&args[0]);
+        match msg_val {
             Ok(Some(msg)) => api.get_res_send(req_no, &msg).await?,
             Ok(None) => {
                 api.rpc()


### PR DESCRIPTION
The major change in this PR is to the naming scheme for methods, variables and types.

Kuska code refers to a Scuttlebutt message in the form of a KVT (Key Value Timestamp) as a "feed". This has been a source of much confusion to me, coming from development in other Scuttlebutt codebases where a feed refers to a sequence of interconnected messages authored by a single keypair. The feed is the collection of messages, never a single message. Messages are now referred to as either message values (just the V in KVT) or message KVTs in the database code.

Documentation coverage has also been significantly improved for the KV store.

Finally, actors which utilise methods from `kv.rs` have also been updated to reflect the revised naming scheme.