### PR TITLE
Add KV tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,7 +1070,7 @@ dependencies = [
 [[package]]
 name = "kuska-ssb"
 version = "0.4.1"
-source = "git+https://github.com/Kuska-ssb/ssb?branch=master#cbebe1633f0c72f165c94226545af2e9c3877c3b"
+source = "git+https://github.com/Kuska-ssb/ssb?branch=master#8e4c9f1d898a7a16a59dc86f77e9e4153a32f0d8"
 dependencies = [
  "async-std",
  "async-stream",

--- a/src/actors/rpc/history_stream.rs
+++ b/src/actors/rpc/history_stream.rs
@@ -201,7 +201,11 @@ where
                 // Append the message to the feed.
                 KV_STORAGE.write().await.append_feed(msg.clone()).await?;
 
-                info!("Received msg no {} from {}", msg.author(), msg.sequence());
+                info!(
+                    "received msg number {} from {}",
+                    msg.author(),
+                    msg.sequence()
+                );
 
                 // Extract blob references from the received message and
                 // request those blobs if they are not already in the local
@@ -219,7 +223,7 @@ where
                 }
             } else {
                 warn!(
-                    "Received out-of-order message from {}; recv: {} db: {}",
+                    "received out-of-order msg from {}; recv: {} db: {}",
                     &msg.author().to_string(),
                     msg.sequence(),
                     last_seq
@@ -354,6 +358,9 @@ where
             "sending history stream to {} (from sequence {} to {})",
             req.args.id, req.from, last_seq
         );
+
+        // TODO: if req.from is greater than last_seq then we shouldn't send
+        // any messages (the requester is more up-to-date than we are).
 
         // Iterate over the range of requested messages, read them from the
         // local key-value database and send them to the requesting peer.


### PR DESCRIPTION
This PR increases test coverage for the primary key-value database (`src/storage/kv.rs`).

It tests the following methods:

- `append_feed(msg)`
- `get_latest_msg_val(&keypair.id)`
- `get_latest_seq(&keypair.id)`
- `get_msg_kvt(&keypair.id, 2)`
- `get_msg_val(&keypair.id, 2)`
- `set_peer(peer_key, peer_seq)`
- `get_peers(peer_key, peer_seq)`