### PR TITLE
Rename get_peers JSON-RPC method

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ operating system)._
 _Undergoing active development. Expect APIs to change._
 
 - [X] json-rpc server for user queries
+  - [X] peers
   - [X] ping
-  - [X] whoami
   - [X] publish
-  - [X] get_peers
+  - [X] whoami
   - [ ] ...
 - [ ] improved connection handler
 - [ ] ebt replication
@@ -83,10 +83,10 @@ The server currently supports HTTP.
 
 | Method | Parameters | Response | Description |
 | --- | --- | --- | --- |
+| `peers` | | `[{ "pub_key": "<@...=.ed25519>", "seq_num": <int> }` | Return the public key and latest sequence number for all peers in the local database |
 | `ping` | | `pong!` | Responds if the JSON-RPC server is running |
+| `publish` | `<content>` | `{ "msg_ref": "<%...=.sha256>", "seq_num": <int> }` | Publishes a message and returns the reference (message hash) and sequence number |
 | `whoami` | | `<@...=.ed25519>` | Returns the public key of the local node |
-| `publish` | `<content>` | `{ "msg_ref": "<%...=.sha256>", "seq": <int> }` | Publishes a message and returns the reference (message hash) and sequence number |
-| `get_peers` | | `[{ "pub_key": "<@...=.ed25519>", "seq_num": <int> }` | Return the public key and latest sequence number for all peers in the local database |
 
 `curl` can be used to invoke the available methods from the commandline:
 

--- a/src/actors/jsonrpc_server.rs
+++ b/src/actors/jsonrpc_server.rs
@@ -37,7 +37,7 @@ pub async fn actor(server_id: OwnedIdentity, port: u16) -> Result<()> {
 
     // Return the public key and latest sequence number for all feeds in the
     // local database.
-    io.add_sync_method("get_peers", |_| {
+    io.add_sync_method("peers", |_| {
         task::block_on(async {
             let db = KV_STORAGE.read().await;
             let peers = db.get_peers().await?;
@@ -79,7 +79,7 @@ pub async fn actor(server_id: OwnedIdentity, port: u16) -> Result<()> {
                 seq
             );
 
-            let response = json![{ "msg_ref": msg.id().to_string(), "seq": seq }];
+            let response = json![{ "msg_ref": msg.id().to_string(), "seq_num": seq }];
 
             Ok(response)
         })


### PR DESCRIPTION
Minor changes:

- `get_peers` becomes `peers`
- `seq` becomes `seq_num` in `publish` response
- README updates

Still unsure about API conventions for the JSON-RPC endpoints but for now I'm going with the following:

- No `get_` prefix for getters (same as Rust API conventions)
- Setters begin with a verb (e.g. `publish`)
- Request and response fields should have consistent naming (ie. `seq_num` throughout, instead of mixing `seq`, `seq_num` and `sequence`)