### PR TITLE
Add message jsonrpc method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ operating system)._
 - [X] automatic feed generation
 - [X] minimal [sled](https://github.com/spacejam/sled) database to store generate feeds
 - [X] mux-rpc implementation
-  - [X] `whoami`
-  - [X] `get`
-  - [X] `createHistoryStream`
   - [X] `blobs createWants`
   - [X] `blobs get`
+  - [X] `createHistoryStream`
+  - [X] `get`
+  - [X] `whoami`
   - [X] [patchwork](https://github.com/ssbc/patchwork) and [go-ssb](https://github.com/ssbc/go-ssb) interoperability
 - [X] legacy replication (using `createHistoryStream`)
 
@@ -62,6 +62,7 @@ operating system)._
 _Undergoing active development. Expect APIs to change._
 
 - [X] json-rpc server for user queries
+  - [X] message
   - [X] peers
   - [X] ping
   - [X] publish
@@ -83,6 +84,7 @@ The server currently supports HTTP.
 
 | Method | Parameters | Response | Description |
 | --- | --- | --- | --- |
+| `message` | `{ "msg_ref": <key> }` | `{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }` | Return a single message KVT (key, value, timestamp) from the local database |
 | `peers` | | `[{ "pub_key": "<@...=.ed25519>", "seq_num": <int> }` | Return the public key and latest sequence number for all peers in the local database |
 | `ping` | | `pong!` | Responds if the JSON-RPC server is running |
 | `publish` | `<content>` | `{ "msg_ref": "<%...=.sha256>", "seq_num": <int> }` | Publishes a message and returns the reference (message hash) and sequence number |

--- a/src/actors/jsonrpc_server.rs
+++ b/src/actors/jsonrpc_server.rs
@@ -13,11 +13,11 @@ use serde_json::json;
 use crate::{broker::*, error::Error, Result, KV_STORAGE};
 
 /// Message reference containing the key (sha256 hash) of a message.
-// This is used to parse the key from the parameters supplied to the `message`
-// endpoint.
+/// Used to parse the key from the parameters supplied to the `message`
+/// endpoint.
 #[derive(Debug, Deserialize)]
 struct MsgRef {
-    key: String,
+    msg_ref: String,
 }
 
 /// Register the JSON-RPC server endpoint, define the JSON-RPC methods
@@ -68,7 +68,7 @@ pub async fn actor(server_id: OwnedIdentity, port: u16) -> Result<()> {
             let db = KV_STORAGE.read().await;
 
             // Retrieve the message value for the requested message.
-            let msg_val = db.get_msg_val(&msg_ref.key)?;
+            let msg_val = db.get_msg_val(&msg_ref.msg_ref)?;
 
             // Retrieve the message KVT for the requested message using the
             // author and sequence fields from the message value.


### PR DESCRIPTION
Exposes a JSON-RPC endpoint for returning the message KVT identified by the given key (sha256 hash).

Returns `null` if the message is not found.

Example output:

```shell
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": {
        "key": "%AeqDvXMLRRJoeoPspbZoCcr2Pz1KV4ai2w31If6JFag=.sha256",
        "rts": null,
        "timestamp": 1671187420.5955684,
        "value": {
            "author": "@MDErHCTxklXc7QZ43fnyzERbRJ7fccRfCYF11EqIFEI=.ed25519",
            "content": {
                "text": "Now playing: HARU NEMURI - Shunka Ryougen (2022)",
                "type": "post"
            },
            "hash": "sha256",
            "previous": "%UIIoYlRaQKp5gG62hccnhCGnBODh2gXRdNfpPTKvwko=.sha256",
            "sequence": 11,
            "signature": "vQa8QS/lJ9dKbsn3sZCegYhL1L67iNEFa/LuCw39raJKxOhvbNs9kerGeFCkw1iOhKGpBq9BZYwojWGBIZUWDA==.sig.ed25519",
            "timestamp": 1671187420592
        }
    }
}
```