### PR TITLE
Expose resync option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,37 @@ message publishing and replication. Indexing of database messages will be
 offloaded to client applications (ie. piping feeds from solar into a SQLite
 database).
 
+## CLI
+
+Solar can be configured and launched using the CLI interface.
+
+`solar --help`
+
+```shell
+🌞 Solar 0.3.1-6266b38
+Sunbathing scuttlecrabs in kuskaland
+
+USAGE:
+    solar [OPTIONS]
+
+    FLAGS:
+        -h, --help       Prints help information
+        -V, --version    Prints version information
+
+    OPTIONS:
+        -c, --connect <connect>        Connect to peers (e.g. host:port:publickey, host:port:publickey)
+        -d, --data <data>              Where data is stored (default: ~/.local/share/local)
+        -j, --jsonrpc <jsonrpc>        Run the JSON-RPC server (default: true)
+        -l, --lan <lan>                Run LAN discovery (default: false)
+        -p, --port <port>              Port to bind (default: 8008)
+        -r, --replicate <replicate>    List of peers to replicate; "connect" magic word means that peers specified with
+                                       --connect are added to the replication list
+            --resync <resync>          Resync the local database by requesting the local feed from peers
+```
+
 ## Quick Start
 
-Clone the source and build the binary:
+Clone the source and build the binary (see [RPi build instructions](https://mycelial.technology/computers/rust-compilation.html) if required):
 
 ```
 git clone git@github.com:mycognosist/solar.git
@@ -55,6 +83,7 @@ operating system)._
   - [X] `get`
   - [X] `whoami`
   - [X] [patchwork](https://github.com/ssbc/patchwork) and [go-ssb](https://github.com/ssbc/go-ssb) interoperability
+- [X] resync local feed from peers
 - [X] legacy replication (using `createHistoryStream`)
 
 ## Extensions
@@ -71,13 +100,6 @@ _Undergoing active development. Expect APIs to change._
   - [ ] ...
 - [ ] improved connection handler
 - [ ] ebt replication
-
-## Documentation
-
-_Undergoing active development._
-
-- [ ] comprehensive doc comments
-- [ ] comprehensive code comments
 
 ## JSON-RPC API
 

--- a/src/actors/rpc/history_stream.rs
+++ b/src/actors/rpc/history_stream.rs
@@ -128,9 +128,15 @@ where
             // If local database resync has been selected...
             if *RESYNC_CONFIG.get().unwrap() {
                 info!("database resync selected; requesting local feed from peers");
+                // Read the local public key from the secret config file.
+                let local_id = &SECRET_CONFIG.get().unwrap().id;
                 // Create a history stream request for the local feed.
-                let args = dto::CreateHistoryStreamIn::new(SECRET_CONFIG.get().unwrap().id.clone());
-                let _ = api.create_history_stream_req_send(&args).await?;
+                let args = dto::CreateHistoryStreamIn::new(local_id.clone()).after_seq(1);
+                let req_id = api.create_history_stream_req_send(&args).await?;
+
+                // Insert the history stream request ID and peer ID
+                // (public key) into the peers hash map.
+                self.peers.insert(req_id, local_id.to_string());
             }
 
             // Loop through all peers in the replication list.

--- a/src/actors/rpc/history_stream.rs
+++ b/src/actors/rpc/history_stream.rs
@@ -16,7 +16,7 @@ use crate::{
     actors::rpc::handler::{RpcHandler, RpcInput},
     broker::{BrokerEvent, ChBrokerSend, Destination},
     storage::kv::StoKvEvent,
-    Result, BLOB_STORAGE, KV_STORAGE, REPLICATION_CONFIG,
+    Result, BLOB_STORAGE, KV_STORAGE, REPLICATION_CONFIG, RESYNC_CONFIG, SECRET_CONFIG,
 };
 
 /// Regex pattern used to match blob references.
@@ -125,15 +125,13 @@ where
         if !self.initialized {
             debug!("initializing history stream handler");
 
-            // TODO: I don't understand why this is being called.
-            // We are essentially requesting our own feed. Why?
-            // Leaving the code here for now until I understand it.
-            // “Don't ever take a fence down until you know the
-            // reason it was put up.” - G. K. Chesterton.
-
-            // Create a history stream request for the local feed.
-            //let args = dto::CreateHistoryStreamIn::new(SECRET_CONFIG.get().unwrap().id.clone());
-            //let _ = api.create_history_stream_req_send(&args).await?;
+            // If local database resync has been selected...
+            if *RESYNC_CONFIG.get().unwrap() {
+                info!("database resync selected; requesting local feed from peers");
+                // Create a history stream request for the local feed.
+                let args = dto::CreateHistoryStreamIn::new(SECRET_CONFIG.get().unwrap().id.clone());
+                let _ = api.create_history_stream_req_send(&args).await?;
+            }
 
             // Loop through all peers in the replication list.
             for peer in &REPLICATION_CONFIG.get().unwrap().peers {


### PR DESCRIPTION
This PR reintroduces the local feed resync option via a CLI flag. Resync defaults to `false` if unset.

I am seeing broken pipe errors for blob get / wants in the logs but only on initial resync. I'm going to look into blobs support more closely to see if we can handle that more gracefully (and maybe not break pipes unnecessarily to begin with).

Small `README` updates have also been introduced:

- Include printout of the CLI help menu
- Add link to RPi build instructions
- Remove documentation todo section

Addresses https://github.com/mycognosist/solar/issues/31