### PR TITLE
Split CLI and application config from main

### DIFF
--- a/src/actors/jsonrpc_server.rs
+++ b/src/actors/jsonrpc_server.rs
@@ -31,7 +31,7 @@ struct PubKey {
 ///
 /// Listens for a termination signal from the broker. When received, the
 /// JSON-RPC server is closed and a terminated signal is sent to the broker.
-pub async fn actor(server_id: OwnedIdentity, port: u16) -> Result<()> {
+pub async fn actor(server_id: OwnedIdentity, server_addr: String) -> Result<()> {
     let broker = BROKER
         .lock()
         .await
@@ -148,7 +148,6 @@ pub async fn actor(server_id: OwnedIdentity, port: u16) -> Result<()> {
     // Return the public key of the local SSB server.
     io.add_sync_method("whoami", move |_| Ok(Value::String(local_pk.to_owned())));
 
-    let server_addr = format!("0.0.0.0:{}", port);
     let server = ServerBuilder::new(io)
         .cors(DomainsValidation::AllowOnly(vec![
             AccessControlAllowOrigin::Null,

--- a/src/actors/rpc/history_stream.rs
+++ b/src/actors/rpc/history_stream.rs
@@ -15,8 +15,9 @@ use regex::Regex;
 use crate::{
     actors::rpc::handler::{RpcHandler, RpcInput},
     broker::{BrokerEvent, ChBrokerSend, Destination},
+    config::{REPLICATION_CONFIG, RESYNC_CONFIG, SECRET_CONFIG},
     storage::kv::StoKvEvent,
-    Result, BLOB_STORAGE, KV_STORAGE, REPLICATION_CONFIG, RESYNC_CONFIG, SECRET_CONFIG,
+    Result, BLOB_STORAGE, KV_STORAGE,
 };
 
 /// Regex pattern used to match blob references.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,39 @@
+use std::path::PathBuf;
+
+use structopt::StructOpt;
+
+// Generate a command line parser.
+// This defines the options that are exposed when running the solar binary.
+#[derive(StructOpt, Debug)]
+#[structopt(name = "🌞 Solar", about = "Sunbathing scuttlecrabs in kuskaland", version=env!("SOLAR_VERSION"))]
+pub struct Cli {
+    /// Where data is stored (default: ~/.local/share/local)
+    #[structopt(short, long, parse(from_os_str))]
+    pub data: Option<PathBuf>,
+
+    /// Connect to peers (e.g. host:port:publickey, host:port:publickey)
+    #[structopt(short, long)]
+    pub connect: Option<String>,
+
+    // TODO: think about other ways of exposing the "connect" feature
+    /// List of peers to replicate; "connect" magic word means that peers
+    /// specified with --connect are added to the replication list
+    #[structopt(short, long)]
+    pub replicate: Option<String>,
+
+    /// Port to bind (default: 8008)
+    #[structopt(short, long)]
+    pub port: Option<u16>,
+
+    /// Run LAN discovery (default: false)
+    #[structopt(short, long)]
+    pub lan: Option<bool>,
+
+    /// Run the JSON-RPC server (default: true)
+    #[structopt(short, long)]
+    pub jsonrpc: Option<bool>,
+
+    /// Resync the local database by requesting the local feed from peers
+    #[structopt(long)]
+    pub resync: Option<bool>,
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 
 use structopt::StructOpt;
 
-// Generate a command line parser.
-// This defines the options that are exposed when running the solar binary.
+/// Generate a command line parser.
+/// This defines the options that are exposed when running the solar binary.
 #[derive(StructOpt, Debug)]
 #[structopt(name = "🌞 Solar", about = "Sunbathing scuttlecrabs in kuskaland", version=env!("SOLAR_VERSION"))]
 pub struct Cli {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,336 @@
+use std::{env, path::PathBuf};
+
+use async_std::{
+    fs::File,
+    io::{ReadExt, WriteExt},
+};
 use kuska_ssb::{
-    crypto::{ToSodiumObject, ToSsbId},
+    crypto::{ed25519, ToSodiumObject, ToSsbId},
     keystore::OwnedIdentity,
 };
+use log::{debug, info};
+use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
+use sled::Config as KvConfig;
+use structopt::StructOpt;
 
 use crate::Result;
+
+// Define the IP used for TCP connections (boxstream and MUXRPC).
+const MUXRPC_IP: &str = "0.0.0.0";
+// Define the port used for TCP connections (boxstream and MUXRPC).
+const MUXRPC_PORT: u16 = 8008;
+// Define the IP used for the JSON-RPC server.
+const JSONRPC_IP: &str = "127.0.0.1";
+// Define the port used for the JSON-RPC server.
+const JSONRPC_PORT: u16 = 3030;
+
+// Write once store for the list of Scuttlebutt peers to replicate.
+pub static REPLICATION_CONFIG: OnceCell<ReplicationConfig> = OnceCell::new();
+// Write once store for the database resync configuration.
+pub static RESYNC_CONFIG: OnceCell<bool> = OnceCell::new();
+// Write-once store for the public-private keypair.
+pub static SECRET_CONFIG: OnceCell<SecretConfig> = OnceCell::new();
+
+/// Generate a command line parser.
+/// This defines the options that are exposed when running the solar binary.
+#[derive(StructOpt, Debug)]
+#[structopt(name = "🌞 Solar", about = "Sunbathing scuttlecrabs in kuskaland", version=env!("SOLAR_VERSION"))]
+struct Cli {
+    /// Where data is stored (default: ~/.local/share/local)
+    #[structopt(short, long, parse(from_os_str))]
+    data: Option<PathBuf>,
+
+    /// Connect to peers (e.g. host:port:publickey, host:port:publickey)
+    #[structopt(short, long)]
+    connect: Option<String>,
+
+    // TODO: think about other ways of exposing the "connect" feature
+    /// List of peers to replicate; "connect" magic word means that peers
+    /// specified with --connect are added to the replication list
+    #[structopt(short, long)]
+    replicate: Option<String>,
+
+    /// Port to bind (default: 8008)
+    #[structopt(short, long)]
+    port: Option<u16>,
+
+    /// Run LAN discovery (default: false)
+    #[structopt(short, long)]
+    lan: Option<bool>,
+
+    /// Run the JSON-RPC server (default: true)
+    #[structopt(short, long)]
+    jsonrpc: Option<bool>,
+
+    /// Resync the local database by requesting the local feed from peers
+    #[structopt(long)]
+    resync: Option<bool>,
+}
+
+/// Application configuration for solar.
+pub struct ApplicationConfig {
+    /// Root data directory.
+    pub base_path: PathBuf,
+
+    /// Path to the blobstore.
+    pub blobs_folder: PathBuf,
+
+    /// Peers to connect to over TCP. Data for each peer connection includes a
+    /// server address, port and peer public key.
+    pub connect: Option<String>,
+
+    /// Path to the feed store.
+    pub feeds_folder: PathBuf,
+
+    /// Run the JSON-RPC server (default: true)
+    pub jsonrpc: bool,
+
+    /// JSON-RPC IP and port to bind (default: 127.0.0.1:3030)
+    pub jsonrpc_addr: String,
+
+    /// Sled key-value cache capacity.
+    pub kv_cache_capacity: u64,
+
+    /// Run LAN discovery (default: false)
+    pub lan_discov: bool,
+
+    /// MUXRPC IP and port to bind (default: 0.0.0.0:8008)
+    pub muxrpc_addr: String,
+
+    /// MUXRPC port to bind (default: 8008)
+    pub muxrpc_port: u16,
+
+    /// List of peers to replicate; "connect" magic word means that peers
+    /// specified with --connect are added to the replication list
+    pub replicate: Option<String>,
+
+    /// Resync the local database by requesting the local feed from peers
+    pub resync: bool,
+}
+
+impl ApplicationConfig {
+    /// Parse the configuration options provided via the CLI and environment
+    /// variables, fall back to defaults when necessary and return the
+    /// application configuration.
+    pub fn from_cli() -> Result<ApplicationConfig> {
+        let cli_args = Cli::from_args();
+
+        // Retrieve application configuration parameters from the parsed CLI input.
+        // Set defaults if options have not been provided.
+        let lan_discov = cli_args.lan.unwrap_or(false);
+        let muxrpc_port = cli_args.port.unwrap_or(MUXRPC_PORT);
+        let muxrpc_addr = format!("{}:{}", MUXRPC_IP, muxrpc_port);
+        let jsonrpc = cli_args.jsonrpc.unwrap_or(true);
+        let resync = cli_args.resync.unwrap_or(false);
+
+        let jsonrpc_ip = match env::var("SOLAR_JSONRPC_IP") {
+            Ok(ip) => ip,
+            Err(_) => JSONRPC_IP.to_string(),
+        };
+        let jsonrpc_port = match env::var("SOLAR_JSONRPC_PORT") {
+            Ok(port) => port,
+            Err(_) => JSONRPC_PORT.to_string(),
+        };
+        let jsonrpc_addr = format!("{}:{}", jsonrpc_ip, jsonrpc_port);
+
+        // Read KV database cache capacity setting from environment variable.
+        // Define default value (1 GB) if env var is unset.
+        let kv_cache_capacity: u64 = match env::var("SLED_CACHE_CAPACITY") {
+            Ok(val) => val.parse().unwrap_or(1000 * 1000 * 1000),
+            Err(_) => 1000 * 1000 * 1000,
+        };
+
+        // Create the root data directory for solar.
+        // This is the path at which application data is stored, including the
+        // public-private keypair, key-value database and blob store.
+        let base_path = cli_args
+            .data
+            .unwrap_or(xdg::BaseDirectories::new()?.create_data_directory("solar")?);
+
+        info!("Base directory is {:?}", base_path);
+
+        let app_config = ApplicationConfig {
+            base_path,
+            blobs_folder: PathBuf::new(),
+            connect: cli_args.connect,
+            feeds_folder: PathBuf::new(),
+            jsonrpc,
+            jsonrpc_addr,
+            kv_cache_capacity,
+            lan_discov,
+            muxrpc_port,
+            muxrpc_addr,
+            replicate: cli_args.replicate,
+            resync,
+        };
+
+        Ok(app_config)
+    }
+
+    /// Configure the application based on CLI options, environment variables
+    /// and defaults.
+    pub async fn configure() -> Result<(
+        ApplicationConfig,
+        KvConfig,
+        Vec<(String, u32, ed25519::PublicKey)>,
+        OwnedIdentity,
+    )> {
+        let mut application_config = ApplicationConfig::from_cli()?;
+
+        let mut secret_key_file = application_config.base_path.clone();
+        let mut replication_config_file = application_config.base_path.clone();
+        let mut feeds_folder = application_config.base_path.clone();
+        let mut blobs_folder = application_config.base_path.clone();
+
+        // Define the filename of the secret config file.
+        secret_key_file.push("secret.toml");
+        // Define the filename of the replication config file.
+        replication_config_file.push("replication.toml");
+        // Define the directory name for the feed store.
+        feeds_folder.push("feeds");
+        // Define the directory name for the blob store.
+        blobs_folder.push("blobs");
+        // Create the feed and blobs directories.
+        std::fs::create_dir_all(&feeds_folder)?;
+        std::fs::create_dir_all(&blobs_folder)?;
+
+        application_config.blobs_folder = blobs_folder;
+        application_config.feeds_folder = feeds_folder;
+
+        // Define configuration parameters for KV database (Sled).
+        let kv_storage_config = KvConfig::new()
+            .path(&application_config.feeds_folder)
+            .cache_capacity(application_config.kv_cache_capacity);
+
+        let mut peer_connections = Vec::new();
+        // Parse peer connection details from the provided CLI options.
+        // Each instance of `host:port:publickey` is separated from the others
+        // and divided into its constituent parts. The tuple of the parts is
+        // then pushed to the `connections` vector.
+        if let Some(connect) = &application_config.connect {
+            for peer in connect.split(',') {
+                let invalid_peer_msg = || format!("invalid peer {}", peer);
+                let parts = peer.split(':').collect::<Vec<&str>>();
+                if parts.len() != 3 {
+                    panic!("{}", invalid_peer_msg());
+                }
+                let server = parts[0].to_string();
+                let port = parts[1]
+                    .parse::<u32>()
+                    .unwrap_or_else(|_| panic!("{}", invalid_peer_msg()));
+                let peer_pk = parts[2]
+                    .to_ed25519_pk_no_suffix()
+                    .unwrap_or_else(|_| panic!("{}", invalid_peer_msg()));
+                peer_connections.push((server, port, peer_pk));
+            }
+        }
+
+        let replication_config = ReplicationConfig::parse_and_update_configuration(
+            &peer_connections,
+            &application_config.replicate,
+            replication_config_file,
+        )
+        .await?;
+
+        // Log the list of public keys identifying peers whose data will be replicated.
+        debug!("peers to be replicated are {:?}", &replication_config.peers);
+
+        let secret_config = SecretConfig::configure(secret_key_file).await?;
+        let owned_identity = secret_config.owned_identity()?;
+
+        // Set the value of the secret configuration cell.
+        let _err = SECRET_CONFIG.set(secret_config);
+        // Set the value of the replication configuration cell.
+        let _err = REPLICATION_CONFIG.set(replication_config);
+        // Set the value of the resync configuration cell.
+        let _err = RESYNC_CONFIG.set(application_config.resync);
+
+        Ok((
+            application_config,
+            kv_storage_config,
+            peer_connections,
+            owned_identity,
+        ))
+    }
+}
+
+/// List of peers whose data will be replicated.
+#[derive(Default, Serialize, Deserialize)]
+pub struct ReplicationConfig {
+    /// Public keys.
+    pub peers: Vec<String>,
+}
+
+impl ReplicationConfig {
+    /// Serialize an instance of `ReplicationConfig` as a TOML byte vector.
+    pub fn to_toml(&self) -> Result<Vec<u8>> {
+        Ok(toml::to_vec(&self)?)
+    }
+
+    /// Deserialize a TOML byte slice into an instance of `ReplicationConfig`.
+    pub fn from_toml(s: &[u8]) -> Result<Self> {
+        Ok(toml::from_slice::<ReplicationConfig>(s)?)
+    }
+
+    /// If the replication config file is not found, generate a new one and
+    /// write it to file.
+    pub async fn configure(replication_config_file: &PathBuf) -> Result<Self> {
+        if !replication_config_file.is_file() {
+            println!(
+                "Replication configuration file not found, generated new one in {:?}",
+                replication_config_file
+            );
+            let config = ReplicationConfig::default();
+            let mut file = File::create(&replication_config_file).await?;
+            file.write_all(&config.to_toml()?).await?;
+            Ok(config)
+        } else {
+            // If the config file exists, open it and read the contents.
+            let mut file = File::open(&replication_config_file).await?;
+            let mut raw: Vec<u8> = Vec::new();
+            file.read_to_end(&mut raw).await?;
+            ReplicationConfig::from_toml(&raw)
+        }
+    }
+
+    /// Parse a list of peers to be replicated and peer connections to be
+    /// attempted. Write the public keys of the replication peers to file
+    /// if they are not already stored there.
+    async fn parse_and_update_configuration(
+        peer_connections: &Vec<(String, u32, ed25519::PublicKey)>,
+        replication_list: &Option<String>,
+        replication_config_file: PathBuf,
+    ) -> Result<Self> {
+        let mut replication_config = ReplicationConfig::configure(&replication_config_file).await?;
+
+        // Parse the list of public keys identifying peers whose data should be
+        // replicated. Write the keys to file if they are not stored there already.
+        if let Some(peers) = replication_list {
+            for peer in peers.split(',') {
+                // If `connect` appears in the input, add the public key of each
+                // peer specified in the `connect` option to the list of peers to
+                // be replicated.
+                if peer == "connect" {
+                    for conn in peer_connections {
+                        let conn_id = format!("@{}", conn.2.to_ssb_id());
+                        if !replication_config.peers.contains(&conn_id) {
+                            replication_config.peers.push(conn_id);
+                        }
+                    }
+                // Prevent duplicate entries by checking if the given public key
+                // is already contained in the config.
+                } else if !replication_config.peers.contains(&peer.to_string()) {
+                    replication_config.peers.push(peer.to_string())
+                }
+            }
+            let mut file = File::create(replication_config_file).await?;
+            file.write_all(&replication_config.to_toml()?).await?;
+        }
+
+        Ok(replication_config)
+    }
+}
 
 /// Public-private keypair.
 #[derive(Serialize, Deserialize)]
@@ -44,29 +370,25 @@ impl SecretConfig {
             sk: self.secret.to_ed25519_sk()?,
         })
     }
-}
 
-/// List of peers whose data will be replicated.
-#[derive(Serialize, Deserialize)]
-pub struct ReplicationConfig {
-    /// Public keys.
-    pub peers: Vec<String>,
-}
-
-impl ReplicationConfig {
-    /// Generate a new instance.
-    // TODO: consider replacing this with a `Default` derivation
-    pub fn create() -> Self {
-        ReplicationConfig { peers: Vec::new() }
-    }
-
-    /// Serialize an instance of `ReplicationConfig` as a TOML byte vector.
-    pub fn to_toml(&self) -> Result<Vec<u8>> {
-        Ok(toml::to_vec(&self)?)
-    }
-
-    /// Deserialize a TOML byte slice into an instance of `ReplicationConfig`.
-    pub fn from_toml(s: &[u8]) -> Result<Self> {
-        Ok(toml::from_slice::<ReplicationConfig>(s)?)
+    /// If the secret config file is not found, generate a new one and write it
+    /// to file. This includes the creation of a unique public-private keypair.
+    pub async fn configure(secret_key_file: PathBuf) -> Result<Self> {
+        if !secret_key_file.is_file() {
+            println!(
+                "Private key not found, generated new one in {:?}",
+                secret_key_file
+            );
+            let config = SecretConfig::create();
+            let mut file = File::create(&secret_key_file).await?;
+            file.write_all(&config.to_toml()?).await?;
+            Ok(config)
+        } else {
+            // If the config file exists, open it and read the contents.
+            let mut file = File::open(&secret_key_file).await?;
+            let mut raw: Vec<u8> = Vec::new();
+            file.read_to_end(&mut raw).await?;
+            SecretConfig::from_toml(&raw)
+        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use sled::Config as KvConfig;
 use structopt::StructOpt;
 
-use crate::Result;
+use crate::{cli::Cli, Result};
 
 // Define the IP used for TCP connections (boxstream and MUXRPC).
 const MUXRPC_IP: &str = "0.0.0.0";
@@ -31,42 +31,6 @@ pub static REPLICATION_CONFIG: OnceCell<ReplicationConfig> = OnceCell::new();
 pub static RESYNC_CONFIG: OnceCell<bool> = OnceCell::new();
 // Write-once store for the public-private keypair.
 pub static SECRET_CONFIG: OnceCell<SecretConfig> = OnceCell::new();
-
-/// Generate a command line parser.
-/// This defines the options that are exposed when running the solar binary.
-#[derive(StructOpt, Debug)]
-#[structopt(name = "🌞 Solar", about = "Sunbathing scuttlecrabs in kuskaland", version=env!("SOLAR_VERSION"))]
-struct Cli {
-    /// Where data is stored (default: ~/.local/share/local)
-    #[structopt(short, long, parse(from_os_str))]
-    data: Option<PathBuf>,
-
-    /// Connect to peers (e.g. host:port:publickey, host:port:publickey)
-    #[structopt(short, long)]
-    connect: Option<String>,
-
-    // TODO: think about other ways of exposing the "connect" feature
-    /// List of peers to replicate; "connect" magic word means that peers
-    /// specified with --connect are added to the replication list
-    #[structopt(short, long)]
-    replicate: Option<String>,
-
-    /// Port to bind (default: 8008)
-    #[structopt(short, long)]
-    port: Option<u16>,
-
-    /// Run LAN discovery (default: false)
-    #[structopt(short, long)]
-    lan: Option<bool>,
-
-    /// Run the JSON-RPC server (default: true)
-    #[structopt(short, long)]
-    jsonrpc: Option<bool>,
-
-    /// Resync the local database by requesting the local feed from peers
-    #[structopt(long)]
-    resync: Option<bool>,
-}
 
 /// Application configuration for solar.
 pub struct ApplicationConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,72 +1,21 @@
 #![recursion_limit = "256"]
 
-use std::{env, path::PathBuf};
-
-use async_std::{
-    fs::File,
-    io::ReadExt,
-    prelude::*,
-    sync::{Arc, RwLock},
-};
-use log::debug;
-use once_cell::sync::{Lazy, OnceCell};
-use sled::Config as KvConfig;
-use structopt::StructOpt;
-
-// Generate a command line parser.
-// This defines the options that are exposed when running the solar binary.
-#[derive(StructOpt, Debug)]
-#[structopt(name = "🌞 Solar", about = "Sunbathing scuttlecrabs in kuskaland", version=env!("SOLAR_VERSION"))]
-struct Opt {
-    /// Where data is stored (default: ~/.local/share/local)
-    #[structopt(short, long, parse(from_os_str))]
-    data: Option<PathBuf>,
-
-    /// Connect to peers (e.g. host:port:publickey, host:port:publickey)
-    #[structopt(short, long)]
-    connect: Option<String>,
-
-    // TODO: think about other ways of exposing the "connect" feature
-    /// List of peers to replicate; "connect" magic word means that peers
-    /// specified with --connect are added to the replication list
-    #[structopt(short, long)]
-    replicate: Option<String>,
-
-    /// Port to bind (default: 8008)
-    #[structopt(short, long)]
-    port: Option<u16>,
-
-    /// Run LAN discovery (default: false)
-    #[structopt(short, long)]
-    lan: Option<bool>,
-
-    /// Run the JSON-RPC server (default: true)
-    #[structopt(short, long)]
-    jsonrpc: Option<bool>,
-
-    /// Resync the local database by requesting the local feed from peers
-    #[structopt(long)]
-    resync: Option<bool>,
-}
+use async_std::sync::{Arc, RwLock};
+use once_cell::sync::Lazy;
 
 mod actors;
 mod broker;
+mod cli;
 mod config;
 mod error;
 mod storage;
 
 use broker::*;
-use config::{ReplicationConfig, SecretConfig};
-use kuska_ssb::crypto::{ToSodiumObject, ToSsbId};
+use config::ApplicationConfig;
 use storage::{blob::BlobStorage, kv::KvStorage};
 
 /// Convenience Result that returns `solar::Error`.
 pub type Result<T> = std::result::Result<T, error::Error>;
-
-// Define the port used for TCP connections (boxstream and MUXRPC).
-const RPC_PORT: u16 = 8008;
-// Define the port used for the JSON-RPC server.
-const JSON_RPC_PORT: u16 = 3030;
 
 // Instantiate the key-value store.
 pub static KV_STORAGE: Lazy<Arc<RwLock<KvStorage>>> =
@@ -75,180 +24,15 @@ pub static KV_STORAGE: Lazy<Arc<RwLock<KvStorage>>> =
 pub static BLOB_STORAGE: Lazy<Arc<RwLock<BlobStorage>>> =
     Lazy::new(|| Arc::new(RwLock::new(BlobStorage::default())));
 
-// Instantiate the application configuration.
-// This includes the public-private keypair.
-pub static SECRET_CONFIG: OnceCell<SecretConfig> = OnceCell::new();
-
-// Instantiate the replication configuration.
-// This is currently just a list of Scuttlebutt peers to replicate.
-pub static REPLICATION_CONFIG: OnceCell<ReplicationConfig> = OnceCell::new();
-
-// Instantiate the database resync configuration.
-pub static RESYNC_CONFIG: OnceCell<bool> = OnceCell::new();
-
 #[async_std::main]
 async fn main() -> Result<()> {
-    // Parse the CLI arguments.
-    let opt = Opt::from_args();
-
-    // Retrieve application configuration parameters from the parsed CLI input.
-    // Set defaults if options have not been provided.
-    let rpc_port = opt.port.unwrap_or(RPC_PORT);
-    let listen = format!("0.0.0.0:{}", rpc_port);
-    let lan_discovery = opt.lan.unwrap_or(false);
-    let jsonrpc_server = opt.jsonrpc.unwrap_or(true);
-    let resync = opt.resync.unwrap_or(false);
-
-    // Set the value of the resync configuration cell.
-    let _err = RESYNC_CONFIG.set(resync);
-
     // Initialise the logger.
     env_logger::init();
     log::set_max_level(log::LevelFilter::max());
 
-    // Create the root data directory for solar.
-    // This is the path at which application data is stored, including the
-    // public-private keypair, key-value database and blob store.
-    let base_path = opt
-        .data
-        .unwrap_or(xdg::BaseDirectories::new()?.create_data_directory("solar")?);
-
-    println!("Base configuration is {:?}", base_path);
-
-    let mut secret_key_file = base_path.clone();
-    let mut replication_config_file = base_path.clone();
-    let mut feeds_folder = base_path.clone();
-    let mut blobs_folder = base_path;
-
-    // Define the filename of the secret config file.
-    secret_key_file.push("secret.toml");
-    // Define the filename of the replication config file.
-    replication_config_file.push("replication.toml");
-    // Define the directory name for the feed store.
-    feeds_folder.push("feeds");
-    // Define the directory name for the blob store.
-    blobs_folder.push("blobs");
-    // Create the feed and blobs directories.
-    std::fs::create_dir_all(&feeds_folder)?;
-    std::fs::create_dir_all(&blobs_folder)?;
-
-    // If the secret config file is not found, generate a new one and write it
-    // to file. This includes the creation of a unique public-private keypair.
-    let secret_config = if !secret_key_file.is_file() {
-        println!(
-            "Private key not found, generated new one in {:?}",
-            secret_key_file
-        );
-        let config = SecretConfig::create();
-        let mut file = File::create(&secret_key_file).await?;
-        file.write_all(&config.to_toml()?).await?;
-        config
-    } else {
-        // If the config file exists, open it and read the contents.
-        let mut file = File::open(&secret_key_file).await?;
-        let mut raw: Vec<u8> = Vec::new();
-        file.read_to_end(&mut raw).await?;
-        SecretConfig::from_toml(&raw)?
-    };
-
-    // If the replication config file is not found, generate a new one and
-    // write it to file.
-    let mut replication_config = if !replication_config_file.is_file() {
-        println!(
-            "Replication configuration file not found, generated new one in {:?}",
-            replication_config_file
-        );
-        let config = ReplicationConfig::create();
-        let mut file = File::create(&replication_config_file).await?;
-        file.write_all(&config.to_toml()?).await?;
-        config
-    } else {
-        // If the config file exists, open it and read the contents.
-        let mut file = File::open(&replication_config_file).await?;
-        let mut raw: Vec<u8> = Vec::new();
-        file.read_to_end(&mut raw).await?;
-        ReplicationConfig::from_toml(&raw)?
-    };
-
-    let mut connects = Vec::new();
-    // Parse peer connection details from the provided CLI options.
-    // Each instance of `host:port:publickey` is separated from the others
-    // and divided into its constituent parts. The tuple of the parts is
-    // then pushed to the `connects` vector.
-    if let Some(connect) = opt.connect {
-        for peer in connect.split(',') {
-            let invalid_peer_msg = || format!("invalid peer {}", peer);
-            let parts = peer.split(':').collect::<Vec<&str>>();
-            if parts.len() != 3 {
-                panic!("{}", invalid_peer_msg());
-            }
-            let server = parts[0].to_string();
-            let port = parts[1]
-                .parse::<u32>()
-                .unwrap_or_else(|_| panic!("{}", invalid_peer_msg()));
-            let peer_pk = parts[2]
-                .to_ed25519_pk_no_suffix()
-                .unwrap_or_else(|_| panic!("{}", invalid_peer_msg()));
-            connects.push((server, port, peer_pk));
-        }
-    }
-
-    // Parse the list of public keys identifying peers whose data should be
-    // replicated. Write the keys to file if they are not stored there already.
-    if let Some(peers) = opt.replicate {
-        for peer in peers.split(',') {
-            // If `connect` appears in the input, add the public key of each
-            // peer specified in the `connect` option to the list of peers to
-            // be replicated.
-            if peer == "connect" {
-                for conn in &connects {
-                    let conn_id = format!("@{}", conn.2.to_ssb_id());
-                    if !replication_config.peers.contains(&conn_id) {
-                        replication_config.peers.push(conn_id);
-                    }
-                }
-            // Prevent duplicate entries by checking if the given public key
-            // is already contained in the config.
-            } else if !replication_config.peers.contains(&peer.to_string()) {
-                replication_config.peers.push(peer.to_string())
-            }
-        }
-        let mut file = File::create(replication_config_file).await?;
-        file.write_all(&replication_config.to_toml()?).await?;
-    }
-
-    // Log the list of public keys idetifying peers whose data will be
-    // replicated.
-    debug!(target:"solar", "peers to be replicated are {:?}", replication_config.peers);
-
-    // Retrieve the public-private keypair of the local solar node.
-    let owned_id = secret_config.owned_identity()?;
-
-    // Set the value of the secret configuration cell.
-    let _err = SECRET_CONFIG.set(secret_config);
-
-    // Set the value of the replication configuration cell.
-    let _err = REPLICATION_CONFIG.set(replication_config);
-
-    // Print 'server started' announcement.
-    println!(
-        "Server started on {}:{}",
-        listen,
-        base64::encode(&owned_id.pk[..])
-    );
-
-    // Read KV database cache capacity setting from environment variable.
-    // Define default value (1 GB) if env var is unset.
-    // TODO: find a neater way to do this. Consider using config file.
-    let kv_cache_capacity: u64 = match env::var("SLED_CACHE_CAPACITY") {
-        Ok(val) => val.parse().unwrap_or(1000 * 1000 * 1000),
-        Err(_) => 1000 * 1000 * 1000,
-    };
-
-    // Define configuration parameters for KV database (Sled).
-    let kv_storage_config = KvConfig::new()
-        .path(&feeds_folder)
-        .cache_capacity(kv_cache_capacity);
+    // Configure the application.
+    let (app_config, kv_storage_config, peer_connections, secret_config) =
+        ApplicationConfig::configure().await?;
 
     // Open the key-value store using the given configuration parameters and
     // an unbounded sender channel for message passing.
@@ -262,33 +46,47 @@ async fn main() -> Result<()> {
     BLOB_STORAGE
         .write()
         .await
-        .open(blobs_folder, BROKER.lock().await.create_sender());
+        .open(app_config.blobs_folder, BROKER.lock().await.create_sender());
 
     // Spawn the ctrlc actor. Listens for SIGINT termination signal.
     Broker::spawn(actors::ctrlc::actor());
+
     // Spawn the TCP server. Facilitates peer connections.
-    Broker::spawn(actors::tcp_server::actor(owned_id.clone(), listen));
+    Broker::spawn(actors::tcp_server::actor(
+        secret_config.clone(),
+        app_config.muxrpc_addr,
+    ));
+
+    // Print 'server started' announcement.
+    println!(
+        "Server started on {}:{}",
+        app_config.muxrpc_port,
+        base64::encode(&secret_config.pk[..])
+    );
 
     // Spawn the JSON-RPC server if the option has been set to true in the
     // CLI arguments. Facilitates operator queries during runtime.
-    if jsonrpc_server {
+    if app_config.jsonrpc {
         Broker::spawn(actors::jsonrpc_server::actor(
-            owned_id.clone(),
-            JSON_RPC_PORT,
+            secret_config.clone(),
+            app_config.jsonrpc_addr,
         ));
     }
 
     // Spawn the LAN discovery actor. Listens for and broadcasts UDP packets
     // to allow LAN-local peer connections.
-    if lan_discovery {
-        Broker::spawn(actors::lan_discovery::actor(owned_id.clone(), RPC_PORT));
+    if app_config.lan_discov {
+        Broker::spawn(actors::lan_discovery::actor(
+            secret_config.clone(),
+            app_config.muxrpc_port,
+        ));
     }
 
     // Spawn the peer actor for each set of provided connection parameters.
     // Facilitates replication.
-    for (server, port, peer_pk) in connects {
+    for (server, port, peer_pk) in peer_connections {
         Broker::spawn(actors::peer::actor(
-            owned_id.clone(),
+            secret_config.clone(),
             actors::peer::Connect::TcpServer {
                 server,
                 port,


### PR DESCRIPTION
Application configuration is now grouped in the same module as replication configuration and secret configuration. This results in a much quieter main module (`src/main.rs`), which is now mainly concerned with triggering application configuration, opening the key-value stores for writing, spawning actors and starting the message loop.

- Move CLI generator and parser into a separate module (`src/cli.rs`)
- Move application configuration into config module (`src/config.rs`)