### PR TITLE
Filter inbound peer connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,25 +49,27 @@ Solar can be configured and launched using the CLI interface.
 `solar --help`
 
 ```shell
-🌞 Solar 0.3.1-1dad14c
+🌞 Solar 0.3.2-02e3f0b
 Sunbathing scuttlecrabs in kuskaland
 
 USAGE:
     solar [OPTIONS]
 
-    FLAGS:
-        -h, --help       Prints help information
-        -V, --version    Prints version information
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
 
-    OPTIONS:
-        -c, --connect <connect>        Connect to peers (e.g. host:port:publickey, host:port:publickey)
-        -d, --data <data>              Where data is stored (default: ~/.local/share/local)
-        -j, --jsonrpc <jsonrpc>        Run the JSON-RPC server (default: true)
-        -l, --lan <lan>                Run LAN discovery (default: false)
-        -p, --port <port>              Port to bind (default: 8008)
-        -r, --replicate <replicate>    List of peers to replicate; "connect" magic word means that peers specified with
-                                       --connect are added to the replication list
-            --resync <resync>          Resync the local database by requesting the local feed from peers
+OPTIONS:
+    -c, --connect <connect>        Connect to peers (e.g. host:port:publickey, host:port:publickey)
+    -d, --data <data>              Where data is stored (default: ~/.local/share/local)
+    -j, --jsonrpc <jsonrpc>        Run the JSON-RPC server (default: true)
+    -l, --lan <lan>                Run LAN discovery (default: false)
+    -p, --port <port>              Port to bind (default: 8008)
+    -r, --replicate <replicate>    List of peers to replicate; "connect" magic word means that peers specified with
+                                   --connect are added to the replication list
+        --resync <resync>          Resync the local database by requesting the local feed from peers
+    -s, --selective <selective>    Only replicate with peers whose public keys are stored in `replication.toml`
+                                   (default: true)
 ```
 
 ## Environment Variables

--- a/src/actors/tcp_server.rs
+++ b/src/actors/tcp_server.rs
@@ -7,7 +7,11 @@ use kuska_ssb::keystore::OwnedIdentity;
 
 use crate::{broker::*, Result};
 
-pub async fn actor(server_id: OwnedIdentity, addr: impl ToSocketAddrs) -> Result<()> {
+pub async fn actor(
+    server_id: OwnedIdentity,
+    addr: impl ToSocketAddrs,
+    selective_replication: bool,
+) -> Result<()> {
     let broker = BROKER.lock().await.register("sbot-listener", false).await?;
 
     let mut ch_terminate = broker.ch_terminate.fuse();
@@ -21,7 +25,7 @@ pub async fn actor(server_id: OwnedIdentity, addr: impl ToSocketAddrs) -> Result
             stream = incoming.next().fuse() => {
                 if let Some(stream) = stream {
                     if let Ok(stream) = stream {
-                        Broker::spawn(super::peer::actor(server_id.clone(), super::peer::Connect::ClientStream{stream}));
+                        Broker::spawn(super::peer::actor(server_id.clone(), super::peer::Connect::ClientStream{stream}, selective_replication));
                     }
                 } else {
                     break;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,4 +36,9 @@ pub struct Cli {
     /// Resync the local database by requesting the local feed from peers
     #[structopt(long)]
     pub resync: Option<bool>,
+
+    /// Only replicate with peers whose public keys are stored in
+    /// `replication.toml` (default: true)
+    #[structopt(short, long)]
+    pub selective: Option<bool>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,8 @@ pub static REPLICATION_CONFIG: OnceCell<ReplicationConfig> = OnceCell::new();
 pub static RESYNC_CONFIG: OnceCell<bool> = OnceCell::new();
 // Write-once store for the public-private keypair.
 pub static SECRET_CONFIG: OnceCell<SecretConfig> = OnceCell::new();
+// Write once store for the selective replication configuration.
+//pub static SELECTIVE_REPLICATION: OnceCell<bool> = OnceCell::new();
 
 /// Application configuration for solar.
 pub struct ApplicationConfig {
@@ -78,6 +80,10 @@ pub struct ApplicationConfig {
 
     /// Resync the local database by requesting the local feed from peers.
     pub resync: bool,
+
+    /// Deny replication attempts from peers who are not defined in the
+    /// replication configuration (default: true).
+    pub selective_replication: bool,
 }
 
 impl ApplicationConfig {
@@ -94,6 +100,7 @@ impl ApplicationConfig {
         let muxrpc_addr = format!("{}:{}", MUXRPC_IP, muxrpc_port);
         let jsonrpc = cli_args.jsonrpc.unwrap_or(true);
         let resync = cli_args.resync.unwrap_or(false);
+        let selective_replication = cli_args.selective.unwrap_or(true);
 
         // Set the JSON-RPC server IP address.
         // First check for an env var before falling back to the default.
@@ -148,6 +155,7 @@ impl ApplicationConfig {
             network_key,
             replicate: cli_args.replicate,
             resync,
+            selective_replication,
         };
 
         Ok(app_config)
@@ -232,6 +240,8 @@ impl ApplicationConfig {
         let _err = RESYNC_CONFIG.set(application_config.resync);
         // Set the value of the secret configuration cell.
         let _err = SECRET_CONFIG.set(secret_config);
+        // Set the value of the unfiltered replication cell.
+        //let _err = UNFILTERED_REPLICATION.set(application_config.unfiltered_replication);
 
         Ok((
             application_config,

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ async fn main() -> Result<()> {
     Broker::spawn(actors::tcp_server::actor(
         secret_config.clone(),
         app_config.muxrpc_addr,
+        app_config.selective_replication,
     ));
 
     // Print the network key.
@@ -85,6 +86,7 @@ async fn main() -> Result<()> {
         Broker::spawn(actors::lan_discovery::actor(
             secret_config.clone(),
             app_config.muxrpc_port,
+            app_config.selective_replication,
         ));
     }
 
@@ -98,6 +100,7 @@ async fn main() -> Result<()> {
                 port,
                 peer_pk,
             },
+            app_config.selective_replication,
         ));
     }
 


### PR DESCRIPTION
Solar already exhibits selective outbound peering and replication: it will only call out to peers who are listed in `replication.toml` (and peer addresses passed in with the `--connect` CLI flag are automatically written to `replication.toml`).

This PR adds selective inbound peering and replication as default. If a peer connects to the local instance but is not listed in `replication.toml`, the connection will be dropped once the secret handshake is complete (required to learn the public key of the caller).

The nonselective replication can be enabled by passing the `--selective false` CLI option.

Sooner or later I need to think about the configuration structure carefully (ie. what is exposed as an env var, a CLI flag or a value in a config file on disk).