### PR TITLE
Update peer replication config to use URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@ cargo build --release
 
 Add peer(s) to `replication.toml` (public key(s) of feeds you wish to replicate):
 
-```
-vim ~/.local/share/solar/replication.toml
+`vim ~/.local/share/solar/replication.toml`
 
-peers = ["@...=.ed25519"]
+```toml
+[peers]
+# Peer data takes the form of key-value pairs.
+# The key is the public key of a peer.
+# The value is a URL specifying the connection address of the peer.
+# The URL takes the form: <scheme>://<host>:<port>?shs=<public key>.
+# The value must be an empty string if the URL is unknown.
+"@...=.ed25519" = ""
 ```
 
 Run solar with LAN discovery enabled:
@@ -49,7 +55,7 @@ Solar can be configured and launched using the CLI interface.
 `solar --help`
 
 ```shell
-🌞 Solar 0.3.2-02e3f0b
+🌞 Solar 0.3.2-1bb6bed
 Sunbathing scuttlecrabs in kuskaland
 
 USAGE:
@@ -62,6 +68,7 @@ FLAGS:
 OPTIONS:
     -c, --connect <connect>        Connect to peers (e.g. host:port:publickey, host:port:publickey)
     -d, --data <data>              Where data is stored (default: ~/.local/share/local)
+    -i, --ip <ip>                  IP to bind (default: 0.0.0.0)
     -j, --jsonrpc <jsonrpc>        Run the JSON-RPC server (default: true)
     -l, --lan <lan>                Run LAN discovery (default: false)
     -p, --port <port>              Port to bind (default: 8008)

--- a/src/actors/peer.rs
+++ b/src/actors/peer.rs
@@ -122,7 +122,13 @@ pub async fn actor_inner(
             // Shutdown the connection if the peer is not in the list of peers
             // to be replicated, unless replication is set to nonselective.
             // This ensures we do not replicate with unknown peers.
-            if selective_replication & !REPLICATION_CONFIG.get().unwrap().peers.contains(&peer_pk) {
+            if selective_replication
+                & !REPLICATION_CONFIG
+                    .get()
+                    .unwrap()
+                    .peers
+                    .contains_key(&peer_pk)
+            {
                 info!(
                     "peer {} is not in replication list and selective replication is enabled; dropping connection",
                     peer_pk

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
 
     // Spawn the peer actor for each set of provided connection parameters.
     // Facilitates replication.
-    for (server, port, peer_pk) in peer_connections {
+    for (_url, server, port, peer_pk) in peer_connections {
         Broker::spawn(actors::peer::actor(
             secret_config.clone(),
             actors::peer::Connect::TcpServer {


### PR DESCRIPTION
This PR adds support for specifying peer connection data in `replication.toml`, in the form of a URL. 

See https://github.com/mycognosist/solar/pull/40 and https://github.com/mycognosist/solar/issues/12 for additional context.

The `replication.toml` configuration file now takes the following form:

```toml
[peers]
# Peer data takes the form of key-value pairs.
# The key is the public key of a peer.
# The value is a URL specifying the connection address of the peer.
# The URL takes the form: <scheme>://<host>:<port>?shs=<public key>.
# The value must be an empty string if the URL is unknown.
"@o8lWpyLeSqV/BJV9pbxFhKpwm6Lw5k+sqexYK+zT9Tc=.ed25519" = "tcp://[200:9730:17c:7f5b:c7c6:c999:7b2a:c958]:8008"
"@HEqy940T6uB+T+d9Jaa58aNfRzLx9eRWqkZljBmnkmk=.ed25519" = ""
```

This is another baby step on the path to implementing a connection manager.