### PR TITLE
Rename sled cache capacity env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ Additional configuration parameters can be supplied via environment variables.
 
 ```
 RUST_LOG
-SLED_CACHE_CAPACITY
 SOLAR_JSONRPC_IP
 SOLAR_JSONRPC_PORT
+SOLAR_KV_CACHE_CAPACITY
 SOLAR_NETWORK_KEY
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,8 +36,6 @@ pub static REPLICATION_CONFIG: OnceCell<ReplicationConfig> = OnceCell::new();
 pub static RESYNC_CONFIG: OnceCell<bool> = OnceCell::new();
 // Write-once store for the public-private keypair.
 pub static SECRET_CONFIG: OnceCell<SecretConfig> = OnceCell::new();
-// Write once store for the selective replication configuration.
-//pub static SELECTIVE_REPLICATION: OnceCell<bool> = OnceCell::new();
 
 /// Application configuration for solar.
 pub struct ApplicationConfig {
@@ -124,7 +122,7 @@ impl ApplicationConfig {
 
         // Read KV database cache capacity setting from environment variable.
         // Define default value (1 GB) if env var is unset.
-        let kv_cache_capacity: u64 = match env::var("SLED_CACHE_CAPACITY") {
+        let kv_cache_capacity: u64 = match env::var("SOLAR_KV_CACHE_CAPACITY") {
             Ok(val) => val.parse().unwrap_or(1000 * 1000 * 1000),
             Err(_) => 1000 * 1000 * 1000,
         };


### PR DESCRIPTION
Improves consistency of environment variable naming.

`SLED_CACHE_CAPACITY` -> `SOLAR_KV_CACHE_CAPACITY`

Also removes two lines of commented code that snuck into `src/config.rs`.