### PR TITLE
fix: return full feed including last message

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Build
       run: cargo build --verbose
     - name: Check formatting

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,5 +20,7 @@ jobs:
       run: cargo build --verbose
     - name: Check formatting
       run: cargo fmt --check --verbose
+    - name: Clippy
+      run: cargo clippy
     - name: Run tests
       run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,24 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Check formatting
+      run: cargo fmt --check --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,6 @@ jobs:
     - name: Check formatting
       run: cargo fmt --check --verbose
     - name: Clippy
-      run: cargo clippy
+      run: cargo clippy -- -D warnings
     - name: Run tests
       run: cargo test --verbose

--- a/src/actors/lan_discovery.rs
+++ b/src/actors/lan_discovery.rs
@@ -28,7 +28,7 @@ pub async fn actor(
 
     loop {
         // Create a UDP socket with the given address.
-        let socket = UdpSocket::bind(format!("0.0.0.0:{}", rpc_port)).await?;
+        let socket = UdpSocket::bind(format!("0.0.0.0:{rpc_port}")).await?;
         // Allow the socket to send packets to the broadcast address.
         socket.set_broadcast(true)?;
 

--- a/src/actors/peer.rs
+++ b/src/actors/peer.rs
@@ -83,7 +83,7 @@ pub async fn actor_inner(
             }
 
             // Define the server address and port.
-            let server_port = format!("{}:{}", server, port);
+            let server_port = format!("{server}:{port}");
             // Attempt a TCP connection.
             let mut stream = TcpStream::connect(server_port).await?;
             // Attempt a secret handshake.
@@ -105,7 +105,7 @@ pub async fn actor_inner(
             let peer_pk = if ssb_id.starts_with('@') {
                 ssb_id
             } else {
-                format!("@{}", ssb_id)
+                format!("@{ssb_id}")
             };
 
             // Check if we are already connected to the selected peer.

--- a/src/actors/rpc/get.rs
+++ b/src/actors/rpc/get.rs
@@ -79,7 +79,7 @@ where
                     .await?
             }
             Err(err) => {
-                let msg = format!("{}", err);
+                let msg = format!("{err}");
                 api.rpc().send_error(req_no, req.rpc_type, &msg).await?
             }
         };

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -185,7 +185,7 @@ impl Broker {
     {
         task::spawn(async move {
             if let Err(e) = fut.await {
-                eprintln!("{}", e)
+                eprintln!("{e}")
             }
         })
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -414,9 +414,7 @@ impl SecretConfig {
     /// to file. This includes the creation of a unique public-private keypair.
     pub async fn configure(secret_key_file: PathBuf) -> Result<Self> {
         if !secret_key_file.is_file() {
-            println!(
-                "Private key not found, generated new one in {secret_key_file:?}"
-            );
+            println!("Private key not found, generated new one in {secret_key_file:?}");
             let config = SecretConfig::create();
             let mut file = File::create(&secret_key_file).await?;
             file.write_all(&config.to_toml()?).await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,7 +101,7 @@ impl ApplicationConfig {
         let lan_discov = cli_args.lan.unwrap_or(false);
         let muxrpc_ip = cli_args.ip.unwrap_or_else(|| MUXRPC_IP.to_string());
         let muxrpc_port = cli_args.port.unwrap_or(MUXRPC_PORT);
-        let muxrpc_addr = format!("{}:{}", muxrpc_ip, muxrpc_port);
+        let muxrpc_addr = format!("{muxrpc_ip}:{muxrpc_port}");
         let jsonrpc = cli_args.jsonrpc.unwrap_or(true);
         let resync = cli_args.resync.unwrap_or(false);
         let selective_replication = cli_args.selective.unwrap_or(true);
@@ -118,7 +118,7 @@ impl ApplicationConfig {
             Ok(port) => port,
             Err(_) => JSONRPC_PORT.to_string(),
         };
-        let jsonrpc_addr = format!("{}:{}", jsonrpc_ip, jsonrpc_port);
+        let jsonrpc_addr = format!("{jsonrpc_ip}:{jsonrpc_port}");
 
         // Read KV database cache capacity setting from environment variable.
         // Define default value (1 GB) if env var is unset.
@@ -294,8 +294,7 @@ impl ReplicationConfig {
     pub async fn configure(replication_config_file: &PathBuf) -> Result<Self> {
         if !replication_config_file.is_file() {
             println!(
-                "Replication configuration file not found, generated new one in {:?}",
-                replication_config_file
+                "Replication configuration file not found, generated new one in {replication_config_file:?}"
             );
             let config = ReplicationConfig::default();
             let mut file = File::create(&replication_config_file).await?;
@@ -416,8 +415,7 @@ impl SecretConfig {
     pub async fn configure(secret_key_file: PathBuf) -> Result<Self> {
         if !secret_key_file.is_file() {
             println!(
-                "Private key not found, generated new one in {:?}",
-                secret_key_file
+                "Private key not found, generated new one in {secret_key_file:?}"
             );
             let config = SecretConfig::create();
             let mut file = File::create(&secret_key_file).await?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,27 +48,27 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Error::AddrParse(err) => write!(f, "failed to parse ip address: {}", err),
-            Error::BaseDirectories(err) => write!(f, "base directory error: {}", err),
-            Error::Crypto(err) => write!(f, "ssb cryptographic error: {}", err),
-            Error::Database(err) => write!(f, "key-value database error: {}", err),
-            Error::DeserializeToml(err) => write!(f, "failed to deserialize toml: {}", err),
+            Error::AddrParse(err) => write!(f, "failed to parse ip address: {err}"),
+            Error::BaseDirectories(err) => write!(f, "base directory error: {err}"),
+            Error::Crypto(err) => write!(f, "ssb cryptographic error: {err}"),
+            Error::Database(err) => write!(f, "key-value database error: {err}"),
+            Error::DeserializeToml(err) => write!(f, "failed to deserialize toml: {err}"),
             // TODO: Attach context so we know the identity of the offending message.
             Error::InvalidSequence => write!(
                 f,
                 "validation error. message contains incorrect sequence number"
             ),
-            Error::Io(err) => write!(f, "i/o error: {}", err),
-            Error::LanDiscovery(err) => write!(f, "lan udp discovery error: {}", err),
-            Error::MuxRpc(err) => write!(f, "muxrpc error: {}", err),
-            Error::SecretHandshake(err) => write!(f, "secret handshake error: {}", err),
-            Error::SerdeCbor(err) => write!(f, "serde cbor error: {}", err),
-            Error::SerdeJson(err) => write!(f, "serde json error: {}", err),
-            Error::SerializeToml(err) => write!(f, "failed to serialize toml: {}", err),
-            Error::SsbApi(err) => write!(f, "ssb api error: {}", err),
-            Error::UrlParse(err) => write!(f, "failed to parse url: {}", err),
-            Error::Validation(err) => write!(f, "message validation error: {}", err),
-            Error::Other(err) => write!(f, "uncategorized error: {}", err),
+            Error::Io(err) => write!(f, "i/o error: {err}"),
+            Error::LanDiscovery(err) => write!(f, "lan udp discovery error: {err}"),
+            Error::MuxRpc(err) => write!(f, "muxrpc error: {err}"),
+            Error::SecretHandshake(err) => write!(f, "secret handshake error: {err}"),
+            Error::SerdeCbor(err) => write!(f, "serde cbor error: {err}"),
+            Error::SerdeJson(err) => write!(f, "serde json error: {err}"),
+            Error::SerializeToml(err) => write!(f, "failed to serialize toml: {err}"),
+            Error::SsbApi(err) => write!(f, "ssb api error: {err}"),
+            Error::UrlParse(err) => write!(f, "failed to parse url: {err}"),
+            Error::Validation(err) => write!(f, "message validation error: {err}"),
+            Error::Other(err) => write!(f, "uncategorized error: {err}"),
         }
     }
 }

--- a/src/storage/blob.rs
+++ b/src/storage/blob.rs
@@ -27,7 +27,7 @@ impl ToBlobHashId for &[u8] {
     fn blob_hash_id(&self) -> String {
         let mut hasher = Sha256::new();
         hasher.update(self);
-        format!("&{}.sha256", base64::encode(&hasher.finalize()))
+        format!("&{}.sha256", base64::encode(hasher.finalize()))
     }
 }
 

--- a/src/storage/kv.rs
+++ b/src/storage/kv.rs
@@ -318,6 +318,93 @@ mod test {
         kv
     }
 
+    #[async_std::test]
+    async fn test_feed_length() -> Result<()> {
+        use kuska_ssb::feed::Message;
+        // Create a unique keypair to sign messages.
+        let keypair = SecretConfig::create().owned_identity().unwrap();
+
+        // Open a temporary key-value store.
+        let kv = open_temporary_kv();
+
+        let mut last_msg: Option<Message> = None;
+        for i in 1..=4 {
+            // Create a post-type message.
+            let msg_content = TypedMessage::Post {
+                text: format!("Important announcement #{}", i),
+                mentions: None,
+            };
+
+            let msg = MessageValue::sign(last_msg.as_ref(), &keypair, json!(msg_content)).unwrap();
+
+            // Append the signed message to the feed. Returns the sequence number
+            // of the appended message.
+            let seq = kv.append_feed(msg).await.unwrap();
+            assert_eq!(seq, i);
+
+            last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+
+            let feed = kv.get_feed(&keypair.id).unwrap();
+            assert_eq!(feed.len(), i as usize);
+        }
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_single_message_content_matches() -> Result<()> {
+        // Create a unique keypair to sign messages.
+        let keypair = SecretConfig::create().owned_identity().unwrap();
+
+        // Open a temporary key-value store.
+        let kv = open_temporary_kv();
+
+        // Create a post-type message.
+        let msg_content = TypedMessage::Post {
+            text: "A strange rambling expiration of my own conscious".to_string(),
+            mentions: None,
+        };
+
+        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+        let msg = MessageValue::sign(last_msg.as_ref(), &keypair, json!(msg_content)).unwrap();
+
+        // Append the signed message to the feed. Returns the sequence number
+        // of the appended message.
+        let seq = kv.append_feed(msg).await.unwrap();
+        assert_eq!(seq, 1);
+
+        let latest_seq = kv.get_latest_seq(&keypair.id).unwrap();
+        assert_eq!(latest_seq, Some(1));
+
+        // Lookup the value of the previous message. This will be `None`
+        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+        assert!(last_msg.is_some());
+        let expected = serde_json::value::to_value(msg_content).unwrap();
+        let last_msg = last_msg.unwrap().content().clone();
+
+        assert_eq!(last_msg, expected);
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_new_feed_is_empty() -> Result<()> {
+        // Create a unique keypair to sign messages.
+        let keypair = SecretConfig::create().owned_identity().unwrap();
+
+        // Open a temporary key-value store.
+        let kv = open_temporary_kv();
+
+        // Lookup the value of the previous message. This will be `None`
+        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+        assert!(last_msg.is_none());
+
+        let latest_seq = kv.get_latest_seq(&keypair.id).unwrap();
+        assert!(latest_seq.is_none());
+
+        Ok(())
+    }
+
     // In reality this test covers more than just the append method.
     // It tests multiple methods exposed by the kv database.
     // The main reason for combining the tests is the cost of setting up

--- a/src/storage/kv.rs
+++ b/src/storage/kv.rs
@@ -138,7 +138,7 @@ impl KvStorage {
     pub fn get_latest_seq(&self, user_id: &str) -> Result<Option<u64>> {
         let db = self.db.as_ref().unwrap();
         let key = Self::key_latest_seq(user_id);
-        let seq = if let Some(value) = db.get(&key)? {
+        let seq = if let Some(value) = db.get(key)? {
             let mut u64_buffer = [0u8; 8];
             u64_buffer.copy_from_slice(&value);
             Some(u64::from_be_bytes(u64_buffer))
@@ -313,7 +313,7 @@ mod test {
         let mut kv = KvStorage::default();
         let (sender, _) = futures::channel::mpsc::unbounded();
         let path = tempdir::TempDir::new("solardb").unwrap();
-        let config = KvConfig::new().path(&path.path());
+        let config = KvConfig::new().path(path.path());
         kv.open(config, sender).unwrap();
         kv
     }
@@ -331,7 +331,7 @@ mod test {
         for i in 1..=4 {
             // Create a post-type message.
             let msg_content = TypedMessage::Post {
-                text: format!("Important announcement #{}", i),
+                text: format!("Important announcement #{i}"),
                 mentions: None,
             };
 
@@ -529,7 +529,7 @@ mod test {
 
         let blob = kv.get_blob("b1")?.unwrap();
 
-        assert_eq!(blob.retrieved, false);
+        assert!(!blob.retrieved);
         assert_eq!(blob.users, ["u7".to_string()].to_vec());
         assert_eq!(
             kv.get_pending_blobs().unwrap(),

--- a/src/storage/kv.rs
+++ b/src/storage/kv.rs
@@ -286,7 +286,7 @@ impl KvStorage {
         // Lookup the latest sequence number for the given peer.
         if let Some(latest_seq) = self.get_latest_seq(user_id)? {
             // Iterate through the messages in the feed.
-            for msg_seq in 1..latest_seq {
+            for msg_seq in 1..=latest_seq {
                 // Get the message KVT for the given author and message
                 // sequence number and add it to the feed vector.
                 // TODO: consider handling the `None` case instead of


### PR DESCRIPTION
probably a typo? before, the `feed` RPC would return all messages *except* the last one. Noticed when a `publish` call returned an unexpected sequence number.