### PR TITLE
Add a minimal connection manager

### DIFF
--- a/src/actors/connection_manager.rs
+++ b/src/actors/connection_manager.rs
@@ -1,5 +1,12 @@
-use async_std::{sync::Mutex, task, task::JoinHandle};
+use std::collections::HashSet;
+
+use async_std::{
+    sync::{Arc, RwLock},
+    task,
+    task::JoinHandle,
+};
 use futures::{select_biased, stream::StreamExt, FutureExt};
+use kuska_ssb::crypto::ed25519;
 use log::trace;
 use once_cell::sync::Lazy;
 
@@ -46,18 +53,25 @@ pub enum ConnectionEvent {
 /// Connection manager (broker).
 #[derive(Debug)]
 pub struct ConnectionManager {
+    /// The public keys of all peers to whom we are currently connected.
+    pub connected_peers: HashSet<ed25519::PublicKey>,
+    /// Idle connection timeout limit.
+    pub idle_timeout_limit: u8,
     /// ID number of the most recently registered connection.
     last_connection_id: usize,
     /// Message loop handle.
     msgloop: Option<JoinHandle<()>>,
-    //active_connections: usize,
+    // TODO: keep a list of active connections.
+    // Then we can query total active connections using `.len()`.
+    //active_connections: HashSet<usize>,
 }
 
-pub static CONNECTION_MANAGER: Lazy<Mutex<ConnectionManager>> =
-    Lazy::new(|| Mutex::new(ConnectionManager::new()));
+/// The connection manager for the solar node.
+pub static CONNECTION_MANAGER: Lazy<Arc<RwLock<ConnectionManager>>> =
+    Lazy::new(|| Arc::new(RwLock::new(ConnectionManager::new())));
 
 impl ConnectionManager {
-    /// Instantiate a new `ConnectionManager` instance.
+    /// Instantiate a new `ConnectionManager`.
     pub fn new() -> Self {
         // Spawn the connection event message loop.
         let msgloop = task::spawn(Self::msg_loop());
@@ -65,7 +79,35 @@ impl ConnectionManager {
         Self {
             last_connection_id: 0,
             msgloop: Some(msgloop),
+            idle_timeout_limit: 30,
+            connected_peers: HashSet::new(),
         }
+    }
+
+    /// Query the number of active peer connections.
+    pub fn count_connections(&self) -> usize {
+        self.connected_peers.len()
+    }
+
+    /// Query whether the list of connected peers contains the given peer.
+    /// Returns `true` if the peer is in the list, otherwise a `false` value is
+    /// returned.
+    pub fn contains_connected_peer(&self, peer_id: &ed25519::PublicKey) -> bool {
+        self.connected_peers.contains(peer_id)
+    }
+
+    /// Add a peer to the list of connected peers.
+    /// Returns `true` if the peer was not already in the list, otherwise a
+    /// `false` value is returned.
+    pub fn insert_connected_peer(&mut self, peer_id: ed25519::PublicKey) -> bool {
+        self.connected_peers.insert(peer_id)
+    }
+
+    /// Remove a peer from the list of connected peers.
+    /// Returns `true` if the peer was in the list, otherwise a `false` value
+    /// is returned.
+    pub fn remove_connected_peer(&mut self, peer_id: ed25519::PublicKey) -> bool {
+        self.connected_peers.remove(&peer_id)
     }
 
     /// Return a handle for the connection event message loop.
@@ -78,7 +120,7 @@ impl ConnectionManager {
         // Increment the last connection ID value.
         self.last_connection_id += 1;
 
-        trace!(target: "connection-manager", "registering new connection: {}", self.last_connection_id);
+        trace!(target: "connection-manager", "registered new connection: {}", self.last_connection_id);
 
         self.last_connection_id
     }
@@ -149,79 +191,108 @@ impl ConnectionManager {
     }
 }
 
-/*
+#[cfg(test)]
+mod test {
+    use super::*;
 
-// LEFT-OVER CODE FROM ACTOR APPROCH
+    use crate::{config::SecretConfig, Result};
 
-// TODO: remove this code when certain of the msgloop approach used above
-
-pub async fn actor() -> Result<()> {
-    if let Err(err) = actor_inner().await {
-        warn!("connection manager failed: {}", err);
-    }
-    Ok(())
-}
-
-pub async fn actor_inner() -> Result<()> {
-    // Register the connection manager actor with the broker.
-    let ActorEndpoint {
-        ch_terminate,
-        ch_broker: _,
-        ch_msg,
-        actor_id: _,
-        ..
-    } = BROKER
-        .lock()
-        .await
-        .register("connection-manager", true)
-        .await?;
-
-    let _connection_manager = ConnectionManager::new();
-
-    // Fuse internal termination channel with external channel.
-    // This allows termination of the peer loop to be initiated from outside
-    // this function.
-    let mut ch_terminate_fuse = ch_terminate.fuse();
-
-    let mut broker_msg_ch = ch_msg.unwrap();
-
-    // Listen for connection events via the broker message bus.
-    loop {
-        select_biased! {
-            _value = ch_terminate_fuse => {
-                break;
-            },
-            msg = broker_msg_ch.next().fuse() => {
-                if let Some(msg) = msg {
-                    if let Some(conn_event) = msg.downcast_ref::<ConnectionEvent>() {
-                        match conn_event {
-                            ConnectionEvent::Connecting(id) => {
-                                trace!(target: "connection-manager", "Connecting: {}", id);
-                            }
-                            ConnectionEvent::Handshaking(id) => {
-                                trace!(target: "connection-manager", "Handshaking: {}", id);
-                            }
-                            ConnectionEvent::Connected(id) => {
-                                trace!(target: "connection-manager", "Connected: {}", id);
-                            } ConnectionEvent::Replicating(id) => {
-                                trace!(target: "connection-manager", "Replicating: {}", id);
-                            }
-                            ConnectionEvent::Disconnecting(id) => {
-                                trace!(target: "connection-manager", "Disconnecting: {}", id);
-                            }
-                            ConnectionEvent::Disconnected(id) => {
-                                trace!(target: "connection-manager", "Disconnected: {}", id);
-                            }
-                            ConnectionEvent::Error(id, err) => {
-                                trace!(target: "connection-manager", "Error: {}: {}", id, err);
-                            }
-                        }
-                    }
-                }
-            },
-        };
+    // A helper function to instantiate a new connection manager for each test.
+    //
+    // If we don't use this approach and simply use CONNECTION_MANAGER
+    // instead, we end up sharing state across tests (since they all end up
+    // operating on the same instance).
+    fn instantiate_new_connection_manager() -> Lazy<Arc<RwLock<ConnectionManager>>> {
+        Lazy::new(|| Arc::new(RwLock::new(ConnectionManager::new())))
     }
 
-    Ok(())
+    #[async_std::test]
+    async fn test_connection_manager_defaults() -> Result<()> {
+        let connection_manager = instantiate_new_connection_manager();
+
+        let connection_idle_timeout_limit = connection_manager.read().await.idle_timeout_limit;
+        assert_eq!(connection_idle_timeout_limit, 30);
+
+        let last_connection_id = connection_manager.read().await.last_connection_id;
+        assert_eq!(last_connection_id, 0);
+
+        let msgloop = &connection_manager.read().await.msgloop;
+        assert!(msgloop.is_some());
+
+        let connected_peers = &connection_manager.read().await.connected_peers;
+        assert!(connected_peers.is_empty());
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_register_new_connection() -> Result<()> {
+        let connection_manager = instantiate_new_connection_manager();
+
+        for i in 1..=4 {
+            // Register a new connection.
+            let connection_id = connection_manager.write().await.register();
+
+            // Ensure the connection ID is incremented for each new connection.
+            assert_eq!(connection_id, i as usize);
+        }
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_count_connections() -> Result<()> {
+        let connection_manager = instantiate_new_connection_manager();
+
+        let active_connections = connection_manager.read().await.count_connections();
+        assert_eq!(active_connections, 0);
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_connected_peers() -> Result<()> {
+        let connection_manager = instantiate_new_connection_manager();
+
+        // Create a unique keypair to sign messages.
+        let keypair = SecretConfig::create().owned_identity().unwrap();
+
+        // Insert a new connected peer.
+        let insert_result = connection_manager
+            .write()
+            .await
+            .insert_connected_peer(keypair.pk);
+        assert_eq!(insert_result, true);
+
+        // Query the list of connected peers.
+        let query_result = connection_manager
+            .read()
+            .await
+            .contains_connected_peer(&keypair.pk);
+        assert_eq!(query_result, true);
+
+        // Attempt to insert the same peer ID for a second time.
+        let reinsert_result = connection_manager
+            .write()
+            .await
+            .insert_connected_peer(keypair.pk);
+        assert_eq!(reinsert_result, false);
+
+        // Count the active connections.
+        let connections = connection_manager.read().await.count_connections();
+        assert_eq!(connections, 1);
+
+        // Remove a peer from the list of connected peers.
+        let remove_result = connection_manager
+            .write()
+            .await
+            .remove_connected_peer(keypair.pk);
+        assert_eq!(remove_result, true);
+
+        // Count the active connections.
+        let conns = connection_manager.read().await.count_connections();
+        assert_eq!(conns, 0);
+
+        Ok(())
+    }
 }
-*/

--- a/src/actors/connection_manager.rs
+++ b/src/actors/connection_manager.rs
@@ -85,7 +85,7 @@ impl ConnectionManager {
     }
 
     /// Query the number of active peer connections.
-    pub fn count_connections(&self) -> usize {
+    pub fn _count_connections(&self) -> usize {
         self.connected_peers.len()
     }
 

--- a/src/actors/connection_manager.rs
+++ b/src/actors/connection_manager.rs
@@ -1,0 +1,54 @@
+// We need to get data out of the `peer_loop` in the peer actor.
+// How to achieve that?
+// One option is to use a message passing channel.
+// Should we use the existing broker messaging system?
+// Or create a secondary event channel?
+
+// I think we should start by leveraging the existing system.
+
+// The peer loop sends a `BrokerEvent::Message` to the connection
+// manager actor. The type of that message value should be `ConnectionEvent`.
+
+/// All possible errors while negotiating connections.
+pub enum ConnectionError {
+    Io(std::io::Error),
+    Handshake,
+}
+
+/// Connection data for a peer.
+pub struct Connection {
+    /// Peer data.
+    peer: PeerData,
+
+    /// Connection state.
+    state: ConnectionState,
+}
+
+#[derive(Debug)]
+/// The state of the connection.
+pub enum ConnectionState {
+    Ready,
+    // Does the message passing approach negate the need for a stateful
+    // struct? At least in terms of the TcpConnection, TcpStream and
+    // HandshakeComplete?
+    Connecting(TcpConnection),
+    Connected(TcpStream, HandshakeComplete),
+    Handshaking,
+    Replicating,
+    Disconnecting(PublicKey),
+    Disconnected,
+    Finished,
+    Error(Option<Error>, Option<PublicKey>),
+}
+
+#[derive(Debug)]
+/// Connection events.
+pub enum ConnectionEvent {
+    Connecting,
+    Connected,
+    Handshaking,
+    Replicating,
+    Disconnecting,
+    Disconnected,
+    Error(ConnectionError),
+}

--- a/src/actors/connection_manager.rs
+++ b/src/actors/connection_manager.rs
@@ -244,7 +244,7 @@ mod test {
     async fn test_count_connections() -> Result<()> {
         let connection_manager = instantiate_new_connection_manager();
 
-        let active_connections = connection_manager.read().await.count_connections();
+        let active_connections = connection_manager.read().await._count_connections();
         assert_eq!(active_connections, 0);
 
         Ok(())
@@ -279,7 +279,7 @@ mod test {
         assert_eq!(reinsert_result, false);
 
         // Count the active connections.
-        let connections = connection_manager.read().await.count_connections();
+        let connections = connection_manager.read().await._count_connections();
         assert_eq!(connections, 1);
 
         // Remove a peer from the list of connected peers.
@@ -290,7 +290,7 @@ mod test {
         assert_eq!(remove_result, true);
 
         // Count the active connections.
-        let conns = connection_manager.read().await.count_connections();
+        let conns = connection_manager.read().await._count_connections();
         assert_eq!(conns, 0);
 
         Ok(())

--- a/src/actors/connection_manager.rs
+++ b/src/actors/connection_manager.rs
@@ -1,54 +1,227 @@
-// We need to get data out of the `peer_loop` in the peer actor.
-// How to achieve that?
-// One option is to use a message passing channel.
-// Should we use the existing broker messaging system?
-// Or create a secondary event channel?
+use async_std::{sync::Mutex, task, task::JoinHandle};
+use futures::{select_biased, stream::StreamExt, FutureExt};
+use log::trace;
+use once_cell::sync::Lazy;
 
-// I think we should start by leveraging the existing system.
+use crate::{ActorEndpoint, BROKER};
 
-// The peer loop sends a `BrokerEvent::Message` to the connection
-// manager actor. The type of that message value should be `ConnectionEvent`.
-
+/*
 /// All possible errors while negotiating connections.
 pub enum ConnectionError {
     Io(std::io::Error),
     Handshake,
 }
 
-/// Connection data for a peer.
+/// Peer connection data.
 pub struct Connection {
     /// Peer data.
     peer: PeerData,
 
     /// Connection state.
     state: ConnectionState,
+
+    /// Connection identifier.
+    id: usize,
 }
 
-#[derive(Debug)]
-/// The state of the connection.
-pub enum ConnectionState {
-    Ready,
-    // Does the message passing approach negate the need for a stateful
-    // struct? At least in terms of the TcpConnection, TcpStream and
-    // HandshakeComplete?
-    Connecting(TcpConnection),
-    Connected(TcpStream, HandshakeComplete),
-    Handshaking,
-    Replicating,
-    Disconnecting(PublicKey),
-    Disconnected,
-    Finished,
-    Error(Option<Error>, Option<PublicKey>),
+impl Connection {
+    pub fn new() {
+    }
 }
+*/
 
+/// Connection events. The `usize` represents the connection ID.
 #[derive(Debug)]
-/// Connection events.
 pub enum ConnectionEvent {
-    Connecting,
-    Connected,
-    Handshaking,
-    Replicating,
-    Disconnecting,
-    Disconnected,
-    Error(ConnectionError),
+    Connecting(usize),
+    Handshaking(usize),
+    Connected(usize),
+    Replicating(usize),
+    Disconnecting(usize),
+    Disconnected(usize),
+    // TODO: use `ConnectionError` instead of `String`.
+    Error(usize, String),
 }
+
+/// Connection manager (broker).
+#[derive(Debug)]
+pub struct ConnectionManager {
+    /// ID number of the most recently registered connection.
+    last_connection_id: usize,
+    /// Message loop handle.
+    msgloop: Option<JoinHandle<()>>,
+    //active_connections: usize,
+}
+
+pub static CONNECTION_MANAGER: Lazy<Mutex<ConnectionManager>> =
+    Lazy::new(|| Mutex::new(ConnectionManager::new()));
+
+impl ConnectionManager {
+    /// Instantiate a new `ConnectionManager` instance.
+    pub fn new() -> Self {
+        // Spawn the connection event message loop.
+        let msgloop = task::spawn(Self::msg_loop());
+
+        Self {
+            last_connection_id: 0,
+            msgloop: Some(msgloop),
+        }
+    }
+
+    /// Return a handle for the connection event message loop.
+    pub fn take_msgloop(&mut self) -> JoinHandle<()> {
+        self.msgloop.take().unwrap()
+    }
+
+    /// Register a new connection with the connection manager.
+    pub fn register(&mut self) -> usize {
+        // Increment the last connection ID value.
+        self.last_connection_id += 1;
+
+        trace!(target: "connection-manager", "registering new connection: {}", self.last_connection_id);
+
+        self.last_connection_id
+    }
+
+    /// Start the connection manager event loop.
+    ///
+    /// Listen for connection event messages via the broker and update
+    /// connection state accordingly.
+    pub async fn msg_loop() {
+        // Register the connection manager actor with the broker.
+        let ActorEndpoint {
+            ch_terminate,
+            ch_broker: _,
+            ch_msg,
+            actor_id: _,
+            ..
+        } = BROKER
+            .lock()
+            .await
+            .register("connection-manager", true)
+            .await
+            .unwrap();
+
+        // Fuse internal termination channel with external channel.
+        // This allows termination of the peer loop to be initiated from outside
+        // this function.
+        let mut ch_terminate_fuse = ch_terminate.fuse();
+
+        let mut broker_msg_ch = ch_msg.unwrap();
+
+        // Listen for connection events via the broker message bus.
+        loop {
+            select_biased! {
+                _value = ch_terminate_fuse => {
+                    break;
+                },
+                msg = broker_msg_ch.next().fuse() => {
+                    if let Some(msg) = msg {
+                        if let Some(conn_event) = msg.downcast_ref::<ConnectionEvent>() {
+                            match conn_event {
+                                ConnectionEvent::Connecting(id) => {
+                                    trace!(target: "connection-manager", "connecting: {}", id);
+                                }
+                                ConnectionEvent::Handshaking(id) => {
+                                    trace!(target: "connection-manager", "handshaking: {}", id);
+                                }
+                                ConnectionEvent::Connected(id) => {
+                                    trace!(target: "connection-manager", "connected: {}", id);
+                                }
+                                ConnectionEvent::Replicating(id) => {
+                                    trace!(target: "connection-manager", "replicating: {}", id);
+                                }
+                                ConnectionEvent::Disconnecting(id) => {
+                                    trace!(target: "connection-manager", "disconnecting: {}", id);
+                                }
+                                ConnectionEvent::Disconnected(id) => {
+                                    trace!(target: "connection-manager", "disconnected: {}", id);
+                                }
+                                ConnectionEvent::Error(id, err) => {
+                                    trace!(target: "connection-manager", "error: {}: {}", id, err);
+                                }
+                            }
+                        }
+                    }
+                },
+            };
+        }
+    }
+}
+
+/*
+
+// LEFT-OVER CODE FROM ACTOR APPROCH
+
+// TODO: remove this code when certain of the msgloop approach used above
+
+pub async fn actor() -> Result<()> {
+    if let Err(err) = actor_inner().await {
+        warn!("connection manager failed: {}", err);
+    }
+    Ok(())
+}
+
+pub async fn actor_inner() -> Result<()> {
+    // Register the connection manager actor with the broker.
+    let ActorEndpoint {
+        ch_terminate,
+        ch_broker: _,
+        ch_msg,
+        actor_id: _,
+        ..
+    } = BROKER
+        .lock()
+        .await
+        .register("connection-manager", true)
+        .await?;
+
+    let _connection_manager = ConnectionManager::new();
+
+    // Fuse internal termination channel with external channel.
+    // This allows termination of the peer loop to be initiated from outside
+    // this function.
+    let mut ch_terminate_fuse = ch_terminate.fuse();
+
+    let mut broker_msg_ch = ch_msg.unwrap();
+
+    // Listen for connection events via the broker message bus.
+    loop {
+        select_biased! {
+            _value = ch_terminate_fuse => {
+                break;
+            },
+            msg = broker_msg_ch.next().fuse() => {
+                if let Some(msg) = msg {
+                    if let Some(conn_event) = msg.downcast_ref::<ConnectionEvent>() {
+                        match conn_event {
+                            ConnectionEvent::Connecting(id) => {
+                                trace!(target: "connection-manager", "Connecting: {}", id);
+                            }
+                            ConnectionEvent::Handshaking(id) => {
+                                trace!(target: "connection-manager", "Handshaking: {}", id);
+                            }
+                            ConnectionEvent::Connected(id) => {
+                                trace!(target: "connection-manager", "Connected: {}", id);
+                            } ConnectionEvent::Replicating(id) => {
+                                trace!(target: "connection-manager", "Replicating: {}", id);
+                            }
+                            ConnectionEvent::Disconnecting(id) => {
+                                trace!(target: "connection-manager", "Disconnecting: {}", id);
+                            }
+                            ConnectionEvent::Disconnected(id) => {
+                                trace!(target: "connection-manager", "Disconnected: {}", id);
+                            }
+                            ConnectionEvent::Error(id, err) => {
+                                trace!(target: "connection-manager", "Error: {}: {}", id, err);
+                            }
+                        }
+                    }
+                }
+            },
+        };
+    }
+
+    Ok(())
+}
+*/

--- a/src/actors/mod.rs
+++ b/src/actors/mod.rs
@@ -1,3 +1,4 @@
+pub mod connection_manager;
 pub mod ctrlc;
 pub mod jsonrpc_server;
 pub mod lan_discovery;

--- a/src/actors/peer.rs
+++ b/src/actors/peer.rs
@@ -311,6 +311,8 @@ async fn peer_loop<R: Read + Unpin + Send + Sync, W: Write + Unpin + Send + Sync
     // Parse the peer public key from the handshake.
     let peer_ssb_id = handshake.peer_pk.to_ssb_id();
 
+    trace!(target: "peer-loop", "initiating peer loop with: {}", peer_ssb_id);
+
     // Instantiate a box stream and split it into reader and writer streams.
     let (box_stream_read, box_stream_write) =
         BoxStream::from_handshake(reader, writer, handshake, 0x8000).split_read_write();
@@ -347,6 +349,8 @@ async fn peer_loop<R: Read + Unpin + Send + Sync, W: Write + Unpin + Send + Sync
     pin_mut!(rpc_recv_stream);
 
     loop {
+        trace!(target: "peer-loop", "peer loop initiated with: {}", peer_ssb_id);
+
         // Poll multiple futures and streams simultaneously, executing the
         // branch for the future that finishes first. If multiple futures are
         // ready, one will be selected in order of declaration.
@@ -370,6 +374,8 @@ async fn peer_loop<R: Read + Unpin + Send + Sync, W: Write + Unpin + Send + Sync
             },
         };
 
+        trace!(target: "peer-loop", "peer loop input: {:?}", input);
+
         let mut handled = false;
         for handler in handlers.iter_mut() {
             match handler.handle(&mut api, &input, &mut ch_broker).await {
@@ -385,7 +391,7 @@ async fn peer_loop<R: Read + Unpin + Send + Sync, W: Write + Unpin + Send + Sync
             }
         }
         if !handled {
-            trace!("message not processed: {:?}", input);
+            trace!(target: "peer-loop", "message not processed: {:?}", input);
         }
     }
 

--- a/src/actors/rpc/history_stream.rs
+++ b/src/actors/rpc/history_stream.rs
@@ -145,7 +145,7 @@ where
                 // Instantiate the history stream request args for the given peer.
                 // The `live` arg means: keep the connection open after initial
                 // replication.
-                let mut args = dto::CreateHistoryStreamIn::new(peer_pk.to_string()).live(true);
+                let mut args = dto::CreateHistoryStreamIn::new(peer_pk.to_string()).live(false);
 
                 // Retrieve the sequence number of the most recent message for
                 // this peer from the local key-value store.

--- a/src/actors/tcp_server.rs
+++ b/src/actors/tcp_server.rs
@@ -23,12 +23,8 @@ pub async fn actor(
         select_biased! {
             _ = ch_terminate => break,
             stream = incoming.next().fuse() => {
-                // TODO: pass message to the broker for the connection manager:
-                // ConnectionEvent::Connecting
                 if let Some(stream) = stream {
                     if let Ok(stream) = stream {
-                        // TODO: pass message to the broker for the connection manager:
-                        // ConnectionEvent::Connected
                         Broker::spawn(super::peer::actor(server_id.clone(), super::peer::Connect::ClientStream{stream}, selective_replication));
                     }
                 } else {

--- a/src/actors/tcp_server.rs
+++ b/src/actors/tcp_server.rs
@@ -23,8 +23,12 @@ pub async fn actor(
         select_biased! {
             _ = ch_terminate => break,
             stream = incoming.next().fuse() => {
+                // TODO: pass message to the broker for the connection manager:
+                // ConnectionEvent::Connecting
                 if let Some(stream) = stream {
                     if let Ok(stream) = stream {
+                        // TODO: pass message to the broker for the connection manager:
+                        // ConnectionEvent::Connected
                         Broker::spawn(super::peer::actor(server_id.clone(), super::peer::Connect::ClientStream{stream}, selective_replication));
                     }
                 } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod config;
 mod error;
 mod storage;
 
+use actors::connection_manager::CONNECTION_MANAGER;
 use broker::*;
 use config::ApplicationConfig;
 use storage::{blob::BlobStorage, kv::KvStorage};
@@ -104,9 +105,13 @@ async fn main() -> Result<()> {
         ));
     }
 
+    // Spawn the connection manager message loop.
+    let connection_manager_msgloop = CONNECTION_MANAGER.lock().await.take_msgloop();
+    connection_manager_msgloop.await;
+
     // Spawn the broker message loop.
-    let msgloop = BROKER.lock().await.take_msgloop();
-    msgloop.await;
+    let broker_msgloop = BROKER.lock().await.take_msgloop();
+    broker_msgloop.await;
 
     println!("Gracefully finished");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
     }
 
     // Spawn the connection manager message loop.
-    let connection_manager_msgloop = CONNECTION_MANAGER.lock().await.take_msgloop();
+    let connection_manager_msgloop = CONNECTION_MANAGER.write().await.take_msgloop();
     connection_manager_msgloop.await;
 
     // Spawn the broker message loop.

--- a/src/storage/kv.rs
+++ b/src/storage/kv.rs
@@ -401,6 +401,12 @@ mod test {
         // and signed message.
         assert_eq!(msg_val.unwrap(), msg_2_clone);
 
+        // Get all messages comprising the feed.
+        let feed = kv.get_feed(&keypair.id).unwrap();
+
+        // Ensure that two messages are returned.
+        assert_eq!(feed.len(), 2);
+
         Ok(())
     }
 


### PR DESCRIPTION
# Connection Manager

See https://github.com/mycognosist/solar/issues/12 for thoughts.

Each new connection is registered with the manager and assigned an ID.

Right now the manager is primarily a connection logger; it listens for `ConnectionEvent` messages on the message bus and logs the events (along with the connection ID). The events themselves are published from the `peer` actor.

I'm aiming to slowly separate connection and replication concerns so that the `peer` actor is only concerned with handshaking and replication. The final separation might look like: 1) connection manager, 2) connection scheduler, 3) connection handler, 4) replication (the `peer` actor).

I have also introduced an idle timeout for peer connections. I noticed during testing that it's possible to get stuck in the replication loop (`peer_loop` in the `peer` actor) - even a dropped connection would not cause it to break. I introduced a timer which counts idle seconds (during which no network or bus messages are received) and breaks out of the loop after n consecutive idle seconds. This may require fine-tuning but it is working.

**TODO**

- [x] Basic connection manager methods
  - [x] new
  - [x] register
  - [x] count_connections
  - [x] contains_connected_peer
  - [x] insert_connected_peer
  - [x] remove_connected_peer
  - [x] msgloop
  - [x] take_msgloop