### PR TITLE
Print more informative error message when user passes bad arguments

### DIFF
--- a/solar/src/config.rs
+++ b/solar/src/config.rs
@@ -129,7 +129,11 @@ impl ApplicationConfig {
         // `peer_connections` vector.
         if let Some(connect) = &application_config.connect {
             for peer_url in connect.split(',') {
-                let parsed_url = Url::parse(peer_url)?;
+                let parsed_url = Url::parse(peer_url).map_err(|e| {
+                    eprintln!("failed to parse peer connection URL: {}", peer_url);
+                    eprintln!("error: {}", e);
+                    e
+                })?;
                 // Retrieve the host from the URL.
                 let server = parsed_url
                     .host()


### PR DESCRIPTION
This took me a little while to figure out and it was mostly because there's literally no feedback at all whe I pass a bad value. Example calls to try this with:

```terminal
# should print an error message with this commit
cargo run -- --connect 'tcp://::1:8080?shs=O4CiyVLNWz6FgU3aTJEUo398O8k9GmEpCXEdriib9MI=.ed25519'

# fine before, and still fine now (note the [] around the IPv6 address)
cargo run -- --connect 'tcp://[::1]:8080?shs=O4CiyVLNWz6FgU3aTJEUo398O8k9GmEpCXEdriib9MI=.ed25519'
```