### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR simply updates the CI workflows to target the `main` branch instead of `master`.

Once this PR is merged I'll update the repo to point to `main` as the primary branch.