### PR TITLE
Add a basic connection scheduler

### DIFF
--- a/solar/README.md
+++ b/solar/README.md
@@ -46,13 +46,13 @@ Peers can be manually added to the replication configuration:
 # Peer data takes the form of key-value pairs.
 # The key is the public key of a peer.
 # The value is a URL specifying the connection address of the peer.
-# The URL takes the form: <scheme>://<host>:<port>?shs=<public key>.
+# The URL takes the form: <scheme>://<host>:<port>.
 # The value must be an empty string if the URL is unknown.
 "@o8lWpyLeSqV/BJV9pbxFhKpwm6Lw5k+sqexYK+zT9Tc=.ed25519" = "tcp://[200:9730:17c:7f5b:c7c6:c999:7b2a:c958]:8008"
 "@HEqy940T6uB+T+d9Jaa58aNfRzLx9eRWqkZljBmnkmk=.ed25519" = ""
 ```
 
-Alternatively, peers can be added to the replication configuration via CLI options:
+Alternatively, peers can be added to the replication configuration via CLI options (note the inclusion of the `shs` query parameter containing the public key of the remote peer):
 
 `solar --connect "tcp://[200:df93:fed8:e5ff:5c43:eab7:6c74:9d94]:8010?shs=MDErHCTxklXc7QZ43fnyzERbRJ7fccRfCYF11EqIFEI=" --replicate connect`
 

--- a/solar/src/actors/network/config.rs
+++ b/solar/src/actors/network/config.rs
@@ -5,9 +5,9 @@ use kuska_ssb::{crypto::ed25519::PublicKey, discovery};
 
 #[derive(Debug, Clone)]
 pub struct NetworkConfig {
-    /// Peer(s) to connect to over TCP. Each entry includes an address
-    /// (IP / hostname and port) and the corresponding public key.
-    pub connect: Vec<(String, PublicKey)>,
+    /// Peer(s) to connect to over TCP. Each entry includes a public key and
+    /// the corresponding address (IP / hostname and port).
+    pub connect: Vec<(PublicKey, String)>,
 
     /// Secret handshake HMAC key (aka. network key, caps key, SHS key).
     pub key: NetworkKey,

--- a/solar/src/actors/network/connection_manager.rs
+++ b/solar/src/actors/network/connection_manager.rs
@@ -146,6 +146,8 @@ impl ConnectionManager {
     ///
     /// Listen for connection event messages via the broker and update
     /// connection state accordingly.
+    // TODO: consider renaming this `start()` in accordance with the connection
+    // scheduler.
     pub async fn msg_loop() {
         // Register the connection manager actor with the broker.
         let ActorEndpoint {

--- a/solar/src/actors/network/connection_scheduler.rs
+++ b/solar/src/actors/network/connection_scheduler.rs
@@ -1,0 +1,179 @@
+/*
+ * Connection Scheduler
+ *
+ * Take a list of peers to connect to (`Vec<(String, PublicKey)>`) and convert to a VecDeque.
+ *
+ * Create two queues (`VecDeque`): `eager` and `lazy`.
+ *
+ * Start by adding the full list of peers to the `eager` queue.
+ *
+ * Dial each peer, one by one, with a delay of x seconds between each dial attempt.
+ *
+ * If the connection and handshake are successful, push the peer to the `eager` queue once the
+ * connection is complete.
+ *
+ * If the connection or handshake are unsuccessful, push the peer to the `lazy` queue once the
+ * connection is complete.
+ *
+ * Dial each peer in the `lazy` queue, one by one, with a delay of x * 10 seconds between each dial
+ * attempt.
+ *
+ * The success or failure of each dial attempt is determined by listening to connection events from
+ * the connection manager. This allows peers to be moved between queues when required.
+*/
+
+use std::{collections::VecDeque, time::Duration};
+
+use async_std::stream;
+use futures::{select_biased, stream::StreamExt, FutureExt};
+use kuska_ssb::crypto::ed25519::PublicKey;
+
+use crate::{
+    actors::network::{connection_manager, connection_manager::ConnectionEvent, secret_handshake},
+    broker::{ActorEndpoint, Broker, BROKER},
+    config::SECRET_CONFIG,
+    Result,
+};
+
+#[derive(Debug)]
+struct ConnectionScheduler {
+    /// Peers with whom the last connection attempt was successful.
+    /// These peers are dialed more frequently than the lazy peers.
+    eager_peers: VecDeque<(String, PublicKey)>,
+    /// Peers with whom the last connection attempt was unsuccessful.
+    /// These peers are dialed less frequently than the eager peers.
+    lazy_peers: VecDeque<(String, PublicKey)>,
+    /// The interval in seconds between dial attempts for eager peers.
+    /// Defaults to 5 seconds.
+    eager_interval: Duration,
+    /// The interval in seconds between dial attempts for lazy peers.
+    /// Defaults to 60 seconds.
+    lazy_interval: Duration,
+}
+
+impl Default for ConnectionScheduler {
+    fn default() -> Self {
+        Self {
+            eager_peers: VecDeque::new(),
+            lazy_peers: VecDeque::new(),
+            eager_interval: Duration::from_secs(5),
+            lazy_interval: Duration::from_secs(60),
+        }
+    }
+}
+
+impl ConnectionScheduler {
+    /// Create a new connection scheduler and populate it with a list of peers
+    /// to dial.
+    fn new(peers: Vec<(String, PublicKey)>) -> Self {
+        let mut scheduler = ConnectionScheduler::default();
+
+        scheduler.eager_peers = VecDeque::from(peers);
+
+        scheduler
+    }
+
+    /// Start the connection scheduler.
+    ///
+    /// Register the connection scheduler with the broker (as an actor), start
+    /// the eager and lazy dialers and  listen for connection events emitted by
+    /// the connection manager. Update the eager and lazy peer queues according
+    /// to connection outcomes.
+    async fn start(mut self, selective_replication: bool) -> Result<()> {
+        // Register the connection scheduler actor with the broker.
+        let ActorEndpoint {
+            ch_terminate,
+            ch_broker: _,
+            ch_msg,
+            actor_id: _,
+            ..
+        } = BROKER
+            .lock()
+            .await
+            .register("connection-scheduler", true)
+            .await
+            .unwrap();
+
+        // Create the tickers (aka. metronomes) which will emit messages at
+        // the predetermined interval. These tickers control the rates at which
+        // we dial peers.
+        let mut eager_ticker = stream::interval(self.eager_interval).fuse();
+        let mut lazy_ticker = stream::interval(self.lazy_interval).fuse();
+
+        // Fuse internal termination channel with external channel.
+        // This allows termination of the scheduler loop to be initiated from
+        // outside this function.
+        let mut ch_terminate_fuse = ch_terminate.fuse();
+
+        let mut broker_msg_ch = ch_msg.unwrap();
+
+        // Listen for connection events via the broker message bus and dial
+        // peers each time an eager or lazy tick is emitted.
+        loop {
+            select_biased! {
+                // Received termination signal. Break out of the loop.
+                _value = ch_terminate_fuse => {
+                    break;
+                },
+                // Eager ticker emitted a tick.
+                eager_tick = eager_ticker.next() => {
+                    if let Some(_tick) = eager_tick {
+                        // Pop a peer from the list of eager peers and dial it.
+                        if let Some((addr, peer_public_key)) = self.eager_peers.pop_front() {
+                            Broker::spawn(secret_handshake::actor(
+                                // TODO: make this neater once config-sharing story has improved.
+                                SECRET_CONFIG.get().unwrap().to_owned_identity()?,
+                                connection_manager::TcpConnection::Dial {
+                                    addr,
+                                    peer_public_key,
+                                },
+                                selective_replication,
+                            ));
+                        }
+                    }
+                },
+                // Lazy ticker emitted a tick.
+                lazy_tick = lazy_ticker.next() => {
+                    if let Some(_tick) = lazy_tick {
+                    // Pop a peer from the list of lazy peers and dial it.
+                    if let Some((addr, peer_public_key)) = self.lazy_peers.pop_front() {
+                            Broker::spawn(secret_handshake::actor(
+                                SECRET_CONFIG.get().unwrap().to_owned_identity()?,
+                                connection_manager::TcpConnection::Dial {
+                                    addr,
+                                    peer_public_key,
+                                },
+                                selective_replication,
+                            ));
+                        }
+                    }
+                },
+                // Received a message from the connection manager via the broker.
+                msg = broker_msg_ch.next().fuse() => {
+                    if let Some(msg) = msg {
+                        if let Some(conn_event) = msg.downcast_ref::<ConnectionEvent>() {
+                            match conn_event {
+                                ConnectionEvent::Connected(id) => {
+                                    todo!()
+                                }
+                                ConnectionEvent::Replicating(id) => {
+                                    todo!()
+                                }
+                                ConnectionEvent::Disconnected(id) => {
+                                    todo!()
+                                }
+                                ConnectionEvent::Error(id, err) => {
+                                    todo!()
+                                }
+                                // Ignore all other connection event variants.
+                                _ => (),
+                            }
+                        }
+                    }
+                },
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/solar/src/actors/network/mod.rs
+++ b/solar/src/actors/network/mod.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod connection_manager;
+pub mod connection_scheduler;
 pub mod lan_discovery;
 pub mod secret_handshake;
 pub mod tcp_server;

--- a/solar/src/actors/network/secret_handshake.rs
+++ b/solar/src/actors/network/secret_handshake.rs
@@ -3,7 +3,7 @@ use std::net::Shutdown;
 use async_std::net::TcpStream;
 use futures::SinkExt;
 use kuska_ssb::{
-    crypto::ToSsbId,
+    crypto::{ToSodiumObject, ToSsbId},
     handshake::async_std::{handshake_client, handshake_server},
     keystore::OwnedIdentity,
 };
@@ -191,7 +191,7 @@ pub async fn actor_inner(
                 & !PEERS_TO_REPLICATE
                     .get()
                     .unwrap()
-                    .contains_key(&peer_public_key)
+                    .contains_key(&peer_public_key.to_ed25519_pk().unwrap())
             {
                 info!(
                     "peer {} is not in replication list and selective replication is enabled; dropping connection",
@@ -221,6 +221,9 @@ pub async fn actor_inner(
     // Parse the peer public key from the handshake.
     let peer_public_key = handshake.peer_pk;
 
+    // TODO: consider moving this into the connection manager.
+    // That will allow us to centralise all transformations to the list.
+    //
     // Add the peer to the list of connected peers.
     CONNECTION_MANAGER
         .write()

--- a/solar/src/actors/replication/config.rs
+++ b/solar/src/actors/replication/config.rs
@@ -5,6 +5,7 @@ use std::{
     path::Path,
 };
 
+use kuska_ssb::crypto::ed25519::PublicKey;
 use serde::{Deserialize, Serialize};
 
 use crate::Result;
@@ -21,10 +22,9 @@ pub struct ReplicationConfig {
     #[serde(skip)]
     pub selective: bool,
 
-    /// List of peers to be replicated. Each entry includes a public key (key)
-    /// and URL (value). The URL contains the host, port and public key of the
-    /// peer's node.
-    pub peers: HashMap<String, String>,
+    /// List of peers to be replicated. Each entry includes a public key and
+    /// a URL. The URL contains the host and port of the peer's node.
+    pub peers: HashMap<PublicKey, String>,
 }
 
 impl Default for ReplicationConfig {

--- a/solar/src/config.rs
+++ b/solar/src/config.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use kuska_sodiumoxide::crypto::auth::Key as NetworkKey;
+use kuska_ssb::crypto::ed25519::PublicKey;
 use log::{debug, info};
 use once_cell::sync::OnceCell;
 use sled::Config as DatabaseConfig;
@@ -18,7 +19,7 @@ use crate::{
 // Write once store for the network key (aka. SHS key or caps key).
 pub static NETWORK_KEY: OnceCell<NetworkKey> = OnceCell::new();
 // Write once store for the list of Scuttlebutt peers to replicate.
-pub static PEERS_TO_REPLICATE: OnceCell<HashMap<String, String>> = OnceCell::new();
+pub static PEERS_TO_REPLICATE: OnceCell<HashMap<PublicKey, String>> = OnceCell::new();
 // Write once store for the database resync configuration.
 pub static RESYNC_CONFIG: OnceCell<bool> = OnceCell::new();
 // Write-once store for the public-private keypair.

--- a/solar/src/node.rs
+++ b/solar/src/node.rs
@@ -2,15 +2,14 @@ use std::net::SocketAddr;
 
 use async_std::sync::{Arc, RwLock};
 use futures::SinkExt;
-use kuska_ssb::crypto::{ed25519::PublicKey, ToSodiumObject};
+use kuska_ssb::crypto::ed25519::PublicKey;
 use once_cell::sync::Lazy;
 
 use crate::{
     actors::{
         jsonrpc,
         network::{
-            connection_manager, connection_manager::CONNECTION_MANAGER, connection_scheduler,
-            lan_discovery, secret_handshake, tcp_server,
+            connection_manager::CONNECTION_MANAGER, connection_scheduler, lan_discovery, tcp_server,
         },
     },
     broker::*,

--- a/solar/src/node.rs
+++ b/solar/src/node.rs
@@ -120,21 +120,6 @@ impl Node {
             config.replication.selective,
         ));
 
-        /*
-        // Spawn the secret handshake actor for each set of provided connection
-        // parameters. This results in an outbound connection attempt.
-        for (peer_public_key, addr) in config.network.connect {
-            Broker::spawn(secret_handshake::actor(
-                config.secret.to_owned_identity()?,
-                connection_manager::TcpConnection::Dial {
-                    addr,
-                    peer_public_key,
-                },
-                config.replication.selective,
-            ));
-        }
-        */
-
         // Spawn the connection manager message loop.
         let connection_manager_msgloop = CONNECTION_MANAGER.write().await.take_msgloop();
         connection_manager_msgloop.await;

--- a/solar_cli/src/main.rs
+++ b/solar_cli/src/main.rs
@@ -206,7 +206,7 @@ impl TryFrom<Cli> for ApplicationConfig {
                 let public_key_without_suffix = public_key.to_ed25519_pk_no_suffix()?;
 
                 // Push the peer connection details to the vector.
-                peer_connections.push((addr, public_key_without_suffix));
+                peer_connections.push((public_key_without_suffix, addr));
             }
         }
 


### PR DESCRIPTION
Addresses https://github.com/mycognosist/solar/issues/63

The main addition of the PR is the connection scheduler module. I've chosen to begin with a very simple implementation. The flow is as follows:

- Combine the list of peers to be dialed from `replication.toml` and `--connect` (CLI) into a single vector
- Spawn the connection scheduler actor, passing in the list of peers to be dialed
- Place all peers to be dialed into an "eager" queue
- Pull one peer from the eager queue every 5 seconds and attempt a connection
  - If the connection fails, push the peer to the "lazy" queue
  - If the connection succeeds, push the peer back to the eager queue
- Pull one peer from the lazy queue every 60 seconds and attempt a connection

I've introduced the `ConnectionData` `struct` in the connection manager which allows the passing of the connection ID, remote peer address and remote peer public key for each connection. The connection data is passed along with each `ConnectionEvent` emitted during the connection and replication lifecycle.

That's really all there is to it. The connection scheduler listens for connection events to determine the post-connection placement of each peer.

-----

I'll aim to further refine the separation of concerns in the next PR (for example, moving modifications of the `CONNECTED_PEERS` vector out of the secret handshake and replication modules and into the connection manager).

This is fun!