### PR TITLE
Extract dialer from scheduler

### DIFF
--- a/solar/src/actors/network/connection.rs
+++ b/solar/src/actors/network/connection.rs
@@ -23,7 +23,7 @@ pub enum TcpConnection {
         /// The address of a remote peer.
         addr: String,
         /// The public key of a remote peer.
-        peer_public_key: ed25519::PublicKey,
+        public_key: ed25519::PublicKey,
     },
     /// An inbound TCP connection.
     Listen { stream: TcpStream },
@@ -151,13 +151,10 @@ pub async fn actor_inner(
     // Handle a TCP connection event (inbound or outbound).
     let (stream, handshake) = match connection {
         // Handle an outbound TCP connection event.
-        TcpConnection::Dial {
-            addr,
-            peer_public_key,
-        } => {
+        TcpConnection::Dial { addr, public_key } => {
             // Update the data associated with this connection.
             connection_data.peer_addr = Some(addr.to_owned());
-            connection_data.peer_public_key = Some(peer_public_key);
+            connection_data.peer_public_key = Some(public_key);
 
             // Send 'connecting' connection event message via the broker.
             ch_broker
@@ -180,8 +177,7 @@ pub async fn actor_inner(
 
             // Attempt a secret handshake.
             let handshake =
-                handshake_client(&mut stream, network_key.to_owned(), pk, sk, peer_public_key)
-                    .await?;
+                handshake_client(&mut stream, network_key.to_owned(), pk, sk, public_key).await?;
 
             info!("💃 connected to peer {}", handshake.peer_pk.to_ssb_id());
 

--- a/solar/src/actors/network/connection_scheduler.rs
+++ b/solar/src/actors/network/connection_scheduler.rs
@@ -2,7 +2,8 @@
 //!
 //! Peers to be dialed are added to the scheduler, with the SSB public key and an address being
 //! provided for each one. These peers are initially placed into an "eager" queue by the scheduler.
-//! Each peer is dialed, one by one, with a delay of x seconds between each dial attempt.
+//! A dial request is emitted for each peer in the "eager" queue, one by one, with a delay of 5
+//! seconds between each request.
 //!
 //! If the connection and handshake are successful, the peer is pushed to the back of the "eager"
 //! queue once the connection is complete.
@@ -10,30 +11,48 @@
 //! If the connection or handshake are unsuccessful, the peer is pushed to the back of the "lazy"
 //! queue once the connection is complete.
 //!
-//! Each peer in the "lazy" queue is dialed, one by one, with a delay of x * 10 seconds between
-//! each dial attempt.
+//! A dial request is emitted for each peer in the "lazy" queue, one by one, with a delay of 61
+//! seconds between each request.
 //!
 //! The success or failure of each dial attempt is determined by listening to connection events from
 //! the connection manager. This allows peers to be moved between queues when required.
-use std::{collections::VecDeque, time::Duration};
+use std::{collections::VecDeque, fmt::Display, time::Duration};
 
 use async_std::stream;
-use futures::{select_biased, stream::StreamExt, FutureExt};
-use kuska_ssb::crypto::ed25519::PublicKey;
+use futures::{select_biased, stream::StreamExt, FutureExt, SinkExt};
+use kuska_ssb::crypto::{ed25519::PublicKey, ToSsbId};
+use log::debug;
 
 use crate::{
-    actors::network::{
-        connection,
-        connection::TcpConnection,
-        connection_manager::{ConnectionEvent, CONNECTION_MANAGER},
-    },
-    broker::{ActorEndpoint, Broker, BROKER},
-    config::SECRET_CONFIG,
+    actors::network::connection_manager::{ConnectionEvent, CONNECTION_MANAGER},
+    broker::{ActorEndpoint, BrokerEvent, Destination, BROKER},
     Result,
 };
 
-/// A request to dial the peer identified by the given public key.
-pub struct DialRequest(pub PublicKey);
+/// A request to dial the peer identified by the given public key and address.
+pub struct DialRequest(pub (PublicKey, String));
+
+// Custom `Display` implementation so we can easily log dial requests.
+impl Display for DialRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (peer_public_key, peer_addr) = match &self {
+            DialRequest((key, addr)) => {
+                let ssb_id = key.to_ssb_id();
+                let peer_public_key = if ssb_id.starts_with('@') {
+                    ssb_id
+                } else {
+                    format!("@{}", ssb_id)
+                };
+
+                let peer_addr = addr.to_string();
+
+                (peer_public_key, peer_addr)
+            }
+        };
+
+        write!(f, "<DialRequest {} / {}>", peer_public_key, peer_addr)
+    }
+}
 
 #[derive(Debug)]
 struct ConnectionScheduler {
@@ -47,7 +66,7 @@ struct ConnectionScheduler {
     /// Defaults to 5 seconds.
     eager_interval: Duration,
     /// The interval in seconds between dial attempts for lazy peers.
-    /// Defaults to 60 seconds.
+    /// Defaults to 61 seconds.
     lazy_interval: Duration,
 }
 
@@ -57,7 +76,7 @@ impl Default for ConnectionScheduler {
             eager_peers: VecDeque::new(),
             lazy_peers: VecDeque::new(),
             eager_interval: Duration::from_secs(5),
-            lazy_interval: Duration::from_secs(60),
+            lazy_interval: Duration::from_secs(61),
         }
     }
 }
@@ -99,14 +118,14 @@ impl ConnectionScheduler {
 /// Start the connection scheduler.
 ///
 /// Register the connection scheduler with the broker (as an actor), start
-/// the eager and lazy dialers and listen for connection events emitted by
-/// the connection manager. Update the eager and lazy peer queues according
-/// to connection outcomes.
-pub async fn actor(peers: Vec<(PublicKey, String)>, selective_replication: bool) -> Result<()> {
+/// the eager and lazy dial request emitters and listen for connection events
+/// emitted by the connection manager. Update the eager and lazy peer queues
+/// according to connection outcomes.
+pub async fn actor(peers: Vec<(PublicKey, String)>) -> Result<()> {
     // Register the connection scheduler actor with the broker.
     let ActorEndpoint {
         ch_terminate,
-        ch_broker: _,
+        mut ch_broker,
         ch_msg,
         actor_id: _,
         ..
@@ -128,7 +147,7 @@ pub async fn actor(peers: Vec<(PublicKey, String)>, selective_replication: bool)
 
     // Create the tickers (aka. metronomes) which will emit messages at
     // the predetermined interval. These tickers control the rates at which
-    // we dial peers.
+    // we emit dial requests for peers.
     let mut eager_ticker = stream::interval(scheduler.eager_interval).fuse();
     let mut lazy_ticker = stream::interval(scheduler.lazy_interval).fuse();
 
@@ -157,16 +176,10 @@ pub async fn actor(peers: Vec<(PublicKey, String)>, selective_replication: bool)
                         if CONNECTION_MANAGER.read().await.contains_connected_peer(&public_key) {
                             scheduler.eager_peers.push_back((public_key, addr))
                         } else {
-                            // Otherwise, dial the peer.
-                            Broker::spawn(connection::actor(
-                                // TODO: make this neater once config-sharing story has improved.
-                                SECRET_CONFIG.get().unwrap().to_owned_identity()?,
-                                TcpConnection::Dial {
-                                    addr,
-                                    public_key,
-                                },
-                                selective_replication,
-                            ));
+                            // Otherwise, send a dial request to the dialer.
+                            let dial_request = DialRequest((public_key, addr));
+                            debug!("{}", dial_request);
+                            ch_broker.send(BrokerEvent::new(Destination::Broadcast, dial_request)).await?
                         }
                     }
                 }
@@ -181,15 +194,10 @@ pub async fn actor(peers: Vec<(PublicKey, String)>, selective_replication: bool)
                         if CONNECTION_MANAGER.read().await.contains_connected_peer(&public_key) {
                             scheduler.eager_peers.push_back((public_key, addr))
                         } else {
-                            // Otherwise, dial the peer.
-                            Broker::spawn(connection::actor(
-                                SECRET_CONFIG.get().unwrap().to_owned_identity()?,
-                                TcpConnection::Dial {
-                                    addr,
-                                    public_key,
-                                },
-                                selective_replication,
-                            ));
+                            // Otherwise, send a dial request to the dialer.
+                            let dial_request = DialRequest((public_key, addr));
+                            debug!("{}", dial_request);
+                            ch_broker.send(BrokerEvent::new(Destination::Broadcast, dial_request)).await?
                         }
                     }
                 }

--- a/solar/src/actors/network/dialer.rs
+++ b/solar/src/actors/network/dialer.rs
@@ -1,0 +1,77 @@
+//! Dialer
+//!
+//! Dial requests are received from the connection scheduler via the broker
+//! message bus. Each request includes the public key of the peer to be dialed.
+//! Upon receiving a request, the dialer queries the address book to determine
+//! the associated address for the peer and then spawns the connection actor.
+
+use futures::{select_biased, FutureExt, StreamExt};
+use kuska_ssb::crypto::ed25519::PublicKey;
+
+use crate::{
+    actors::network::{connection, connection::TcpConnection, connection_scheduler::DialRequest},
+    broker::{ActorEndpoint, Broker, BROKER},
+    config::SECRET_CONFIG,
+    Result,
+};
+
+/// Start the dialer.
+///
+/// Register the connection dialer with the broker (as an actor) and listen
+/// for dial requests from the scheduler. Once received, use the attached
+/// public key to lookup the outbound address from the address book and dial
+/// the peer by spawning the connection actor.
+pub async fn actor(peers: Vec<(PublicKey, String)>, selective_replication: bool) -> Result<()> {
+    // Register the connection dialer actor with the broker.
+    let ActorEndpoint {
+        ch_terminate,
+        ch_broker: _,
+        ch_msg,
+        actor_id: _,
+        ..
+    } = BROKER.lock().await.register("dialer", true).await?;
+
+    // Fuse internal termination channel with external channel.
+    // This allows termination of the dialer loop to be initiated from
+    // outside this function.
+    let mut ch_terminate_fuse = ch_terminate.fuse();
+
+    let mut broker_msg_ch = ch_msg.unwrap();
+
+    // Listen for dial-peer events via the broker message bus, lookup
+    // the associated address and dial the peer.
+    loop {
+        select_biased! {
+            // Received termination signal. Break out of the loop.
+            _value = ch_terminate_fuse => {
+                break;
+            },
+            // Received a message from the connection scheduler via the broker.
+            msg = broker_msg_ch.next().fuse() => {
+                if let Some(msg) = msg {
+                    if let Some(dial_request) = msg.downcast_ref::<DialRequest>() {
+                        match dial_request {
+                            DialRequest(public_key) => {
+                                // Retrieve the address associated with this key.
+                                if let addr = AddressBook::get(public_key) {
+                                    // Spawn the connection actor.
+                                    Broker::spawn(connection::actor(
+                                        SECRET_CONFIG.get().unwrap().to_owned_identity()?,
+                                        TcpConnection::Dial {
+                                            addr,
+                                            public_key,
+                                        },
+                                        selective_replication,
+                                    ));
+                                }
+                            }
+                            _ => (),
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/solar/src/actors/network/dialer.rs
+++ b/solar/src/actors/network/dialer.rs
@@ -45,21 +45,15 @@ pub async fn actor(selective_replication: bool) -> Result<()> {
             // Received a message from the connection scheduler via the broker.
             msg = broker_msg_ch.next().fuse() => {
                 if let Some(msg) = msg {
-                    // TODO: see if it's possible to downcast (ie. no ref).
-                    if let Some(dial_request) = msg.downcast_ref::<DialRequest>() {
-                        match dial_request {
-                            DialRequest((public_key, addr)) => {
-                                // Spawn the connection actor.
-                                Broker::spawn(connection::actor(
-                                    SECRET_CONFIG.get().unwrap().to_owned_identity()?,
-                                    TcpConnection::Dial {
-                                        addr: addr.to_string(),
-                                        public_key: *public_key,
-                                    },
-                                    selective_replication,
-                                ));
-                            }
-                        }
+                    if let Some(DialRequest((public_key, addr))) = msg.downcast_ref::<DialRequest>() {
+                        Broker::spawn(connection::actor(
+                            SECRET_CONFIG.get().unwrap().to_owned_identity()?,
+                            TcpConnection::Dial {
+                                addr: addr.to_string(),
+                                public_key: *public_key,
+                            },
+                            selective_replication,
+                        ));
                     }
                 }
             }

--- a/solar/src/actors/network/lan_discovery.rs
+++ b/solar/src/actors/network/lan_discovery.rs
@@ -88,16 +88,13 @@ async fn process_broadcast(
 
     // Attempt to parse the IP / hostname, port and public key from the received
     // UDP broadcast message.
-    if let Some((server, port, peer_public_key)) = LanBroadcast::parse(&msg) {
+    if let Some((server, port, public_key)) = LanBroadcast::parse(&msg) {
         let addr = format!("{server}:{port}");
 
         // Spawn a connection actor with the given connection parameters.
         Broker::spawn(connection::actor(
             server_id.clone(),
-            TcpConnection::Dial {
-                addr,
-                peer_public_key,
-            },
+            TcpConnection::Dial { addr, public_key },
             selective_replication,
         ));
     } else {

--- a/solar/src/actors/network/mod.rs
+++ b/solar/src/actors/network/mod.rs
@@ -2,5 +2,6 @@ pub mod config;
 pub mod connection;
 pub mod connection_manager;
 pub mod connection_scheduler;
+pub mod dialer;
 pub mod lan_discovery;
 pub mod tcp_server;


### PR DESCRIPTION
This PR introduces the `dialer` actor module which listens for `DialRequest` messages emitted by the connection scheduler and dials peers accordingly.

The `DialRequest` messages currently include the public key and address of the peer to be dialed. In the next iteration, the address requirement will be removed. Instead, the dialer will receive the `DialRequest` message and use the public key of the peer to query the corresponding address from the address book. 

Related to https://github.com/mycognosist/solar/issues/72