### PR TITLE
Add basic message content indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ lightweight replication and feed storage. Much like
 [scuttlego](https://github.com/planetary-social/scuttlego), this fork is not
 intended to reproduce the full suite of MUXRPC methods used in the JS SSB
 ecosystem. It will only implement the core MUXRPC methods required for 
-message publishing and replication. Indexing of database messages will be
-offloaded to client applications (ie. piping feeds from solar into a SQLite
-database).
+message publishing and replication. Indexes are provided to facilitate client
+creation.
 
 ## Features
 
@@ -38,6 +37,7 @@ database).
  - **Selective replication:** Only replicate with specified peers
  - **JSON-RPC interface:** Interact with the node using JSON-RPC over HTTP
  - **Alternative network key:** Operate with a unique network key
+ - **Database indexes:** Look up state with efficient queries
 
 _¹ - this is possible because those implementations support legacy replication (using `createHistoryStream`)_
 

--- a/solar/README.md
+++ b/solar/README.md
@@ -4,7 +4,7 @@ A minimal, embeddable Secure Scuttlebutt node capable of lightweight replication
 
 :warning: **Solar is alpha software; expect breaking changes** :construction:
 
-[Features](#features) | [Development](#development) | [Configuration](#configuration) | [JSON-RPC API](#json-rpc) | [License](#license)
+[Features](#features) | [Development](#development) | [Configuration](#configuration) | [JSON-RPC API](#json-rpc) | [Indexes](#indexes) | [License](#license)
 
 ## Features
 
@@ -18,6 +18,7 @@ A minimal, embeddable Secure Scuttlebutt node capable of lightweight replication
  - **Selective replication:** Only replicate with specified peers
  - **JSON-RPC interface:** Interact with the node using JSON-RPC over HTTP
  - **Alternative network key:** Operate with a unique network key
+ - **Database indexes:** Look up state with efficient queries
 
 _¹ - this is possible because those implementations support legacy replication (using `createHistoryStream`)_
 
@@ -98,6 +99,10 @@ _Note: You might find it easier to save your JSON to file and pass that to `curl
 ```
 curl -X POST -H "Content-Type: application/json" --data @publish.json 127.0.0.1:3030
 ```
+
+## Indexes
+
+Database indexes are provided to allow efficient queries of the underlying data. The indexes cover most of the message types commonly of relevance to client development. See the tests in the `indexes` module for usage examples (`solar/src/storage/indexes.rs`).
 
 ## License
 

--- a/solar/src/actors/muxrpc/history_stream.rs
+++ b/solar/src/actors/muxrpc/history_stream.rs
@@ -208,6 +208,9 @@ where
             // convert that into a message value. Return an error if that fails.
             // This approach allows us to handle the unlikely event that
             // messages are sent as KVTs and not simply values.
+            //
+            // Validation of the message signature and fields is also performed
+            // as part of the call to `from_slice`.
             let msg = match Message::from_slice(res) {
                 Ok(msg) => msg,
                 Err(_) => MessageKvt::from_slice(res)?.into_message()?,

--- a/solar/src/error.rs
+++ b/solar/src/error.rs
@@ -31,6 +31,8 @@ pub enum Error {
     JsonRpc(jsonrpsee::core::Error),
     /// LAN UDP discovery error.
     LanDiscovery(discovery::Error),
+    /// SSB message type field error.
+    MessageType(String),
     /// SSB RPC error.
     MuxRpc(rpc::Error),
     /// Secret handshake error.
@@ -73,6 +75,7 @@ impl fmt::Display for Error {
             Error::Io(err) => write!(f, "I/O error: {err}"),
             Error::JsonRpc(err) => write!(f, "JSON-RPC error: {err}"),
             Error::LanDiscovery(err) => write!(f, "LAN UDP discovery error: {err}"),
+            Error::MessageType(err) => write!(f, "SSB message type field error: {err}"),
             Error::MuxRpc(err) => write!(f, "MUXRPC error: {err}"),
             Error::SecretHandshake(err) => write!(f, "Secret handshake error: {err}"),
             Error::SerdeCbor(err) => write!(f, "Serde CBOR error: {err}"),

--- a/solar/src/storage/indexes.rs
+++ b/solar/src/storage/indexes.rs
@@ -1,0 +1,488 @@
+use std::collections::HashSet;
+
+use kuska_ssb::{
+    api::dto::content::{Image, TypedMessage as MessageContent},
+    feed::Message as MessageValue,
+};
+use sled::{Db, Tree};
+
+use crate::Result;
+
+/// Database indexes, each stored in a tree of the main database.
+pub struct Indexes {
+    /// Channel subscribers.
+    channel_subscribers: Tree,
+    /// Channel subscriptions.
+    channel_subscriptions: Tree,
+    /// Descriptions.
+    descriptions: Tree,
+    /// Image references.
+    images: Tree,
+    /// Names.
+    names: Tree,
+}
+
+impl Indexes {
+    /// Instantiate the indexes.
+    fn new(
+        channel_subscribers: Tree,
+        channel_subscriptions: Tree,
+        descriptions: Tree,
+        images: Tree,
+        names: Tree,
+    ) -> Self {
+        Self {
+            channel_subscribers,
+            channel_subscriptions,
+            descriptions,
+            images,
+            names,
+        }
+    }
+
+    /// Open a database tree for each index.
+    pub fn open(db: &Db) -> Result<Indexes> {
+        let channel_subscribers = db.open_tree("channel_subscribers")?;
+        let channel_subscriptions = db.open_tree("channel_subscriptions")?;
+        let descriptions = db.open_tree("descriptions")?;
+        let images = db.open_tree("images")?;
+        let names = db.open_tree("names")?;
+
+        let indexes = Indexes::new(
+            channel_subscribers,
+            channel_subscriptions,
+            descriptions,
+            images,
+            names,
+        );
+
+        Ok(indexes)
+    }
+
+    /// Index a message based on the author (SSB ID) and content type.
+    pub fn index_msg(&self, author: &str, msg_val: MessageValue) -> Result<()> {
+        if let Some(content_val) = msg_val.value.get("content") {
+            let content: MessageContent = serde_json::from_value(content_val.to_owned())?;
+
+            match content {
+                MessageContent::About { .. } => self.index_about(author, content)?,
+                MessageContent::Channel {
+                    channel,
+                    subscribed,
+                } => self.index_channel(author, channel, subscribed)?,
+                _ => (),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Index the content of an about-type message.
+    fn index_about(&self, user_id: &str, msg_content: MessageContent) -> Result<()> {
+        // Match on each field of an about-type message and call each individual
+        // indexer as required. This allows us to catch the possibility that
+        // multiple fields are set in a single message (such as name and
+        // description).
+        if let MessageContent::About {
+            about,
+            description,
+            image,
+            name,
+            ..
+        } = msg_content
+        {
+            if let Some(description) = description {
+                self.index_description(user_id, &about, description)?
+            }
+            if let Some(image) = image {
+                self.index_image(user_id, &about, image)?
+            }
+            if let Some(name) = name {
+                self.index_name(user_id, &about, name)?
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Add the given channel to the channel index.
+    fn index_channel(&self, user_id: &str, channel: String, subscribed: bool) -> Result<()> {
+        self.index_channel_subscriber(user_id, &channel, subscribed)?;
+        self.index_channel_subscription(user_id, &channel, subscribed)?;
+
+        Ok(())
+    }
+
+    /// Update the channel subscribers index for the given public key, channel
+    /// and subscription state.
+    fn index_channel_subscriber(
+        &self,
+        user_id: &str,
+        channel: &str,
+        subscribed: bool,
+    ) -> Result<()> {
+        let mut subscribers = self.get_channel_subscribers(channel)?;
+
+        if subscribed {
+            subscribers.insert(user_id.to_owned());
+        } else {
+            subscribers.remove(user_id);
+        }
+
+        self.channel_subscribers
+            .insert(channel, serde_cbor::to_vec(&subscribers)?)?;
+
+        Ok(())
+    }
+
+    /// Return all subscribers of the given channel.
+    fn get_channel_subscribers(&self, channel: &str) -> Result<HashSet<String>> {
+        let subscribers = if let Some(raw) = self.channel_subscribers.get(channel)? {
+            serde_cbor::from_slice::<HashSet<String>>(&raw)?
+        } else {
+            HashSet::new()
+        };
+
+        Ok(subscribers)
+    }
+
+    /// Update the channel subscription index for the given public key, channel
+    /// and subscription state.
+    fn index_channel_subscription(
+        &self,
+        user_id: &str,
+        channel: &str,
+        subscribed: bool,
+    ) -> Result<()> {
+        let mut subscriptions = self.get_channel_subscriptions(user_id)?;
+
+        if subscribed {
+            subscriptions.insert(channel.to_owned());
+        } else {
+            subscriptions.remove(channel);
+        }
+
+        self.channel_subscriptions
+            .insert(user_id, serde_cbor::to_vec(&subscriptions)?)?;
+
+        Ok(())
+    }
+
+    /// Return all the channel subscriptions for the given public key.
+    fn get_channel_subscriptions(&self, user_id: &str) -> Result<HashSet<String>> {
+        let subscriptions = if let Some(raw) = self.channel_subscriptions.get(user_id)? {
+            serde_cbor::from_slice::<HashSet<String>>(&raw)?
+        } else {
+            HashSet::new()
+        };
+
+        Ok(subscriptions)
+    }
+
+    /// Add the given description to the description index for the associated
+    /// public key.
+    fn index_description(
+        &self,
+        author_id: &str,
+        about_id: &str,
+        description: String,
+    ) -> Result<()> {
+        let mut descriptions = self.get_descriptions(about_id)?;
+        descriptions.push((author_id.to_owned(), description));
+        self.descriptions
+            .insert(about_id, serde_cbor::to_vec(&descriptions)?)?;
+
+        Ok(())
+    }
+
+    /// Return all indexed descriptions for the given public key.
+    fn get_descriptions(&self, user_id: &str) -> Result<Vec<(String, String)>> {
+        let descriptions = if let Some(raw) = self.descriptions.get(user_id)? {
+            serde_cbor::from_slice::<Vec<(String, String)>>(&raw)?
+        } else {
+            Vec::new()
+        };
+
+        Ok(descriptions)
+    }
+
+    /// Return all indexed self-assigned descriptions for the given public key.
+    fn get_self_assigned_descriptions(&self, user_id: &str) -> Result<Vec<(String, String)>> {
+        let mut descriptions = self.get_descriptions(user_id)?;
+        descriptions.retain(|(author, _description)| author == user_id);
+
+        Ok(descriptions)
+    }
+
+    /// Return the most recently indexed description for the given public key.
+    fn get_latest_description(&self, user_id: &str) -> Result<Option<(String, String)>> {
+        let descriptions = self.get_descriptions(user_id)?;
+        let description = descriptions.last().cloned();
+
+        Ok(description)
+    }
+
+    /// Return the most recently indexed self-assigned description for the given
+    /// public key.
+    fn get_latest_self_assigned_description(
+        &self,
+        user_id: &str,
+    ) -> Result<Option<(String, String)>> {
+        let self_descriptions = self.get_self_assigned_descriptions(user_id)?;
+        let description = self_descriptions.last().cloned();
+
+        Ok(description)
+    }
+
+    /// Add the given image reference to the image index for the associated
+    /// public key.
+    fn index_image(&self, author_id: &str, about_id: &str, image: Image) -> Result<()> {
+        // TODO: Handle `Image::Complete { .. }` variant.
+        if let Image::OnlyLink(ssb_hash) = image {
+            let mut images = self.get_images(about_id)?;
+            images.push((author_id.to_owned(), ssb_hash));
+            self.images.insert(about_id, serde_cbor::to_vec(&images)?)?;
+        }
+
+        Ok(())
+    }
+
+    /// Return all indexed image references for the given public key.
+    fn get_images(&self, user_id: &str) -> Result<Vec<(String, String)>> {
+        let images = if let Some(raw) = self.images.get(user_id)? {
+            serde_cbor::from_slice::<Vec<(String, String)>>(&raw)?
+        } else {
+            Vec::new()
+        };
+
+        Ok(images)
+    }
+
+    /// Return all indexed self-assigned image references for the given public
+    /// key.
+    fn get_self_assigned_images(&self, user_id: &str) -> Result<Vec<(String, String)>> {
+        let mut images = self.get_images(user_id)?;
+        images.retain(|(author, _image)| author == user_id);
+
+        Ok(images)
+    }
+
+    /// Return the most recently indexed image reference for the given public
+    /// key.
+    fn get_latest_image(&self, user_id: &str) -> Result<Option<(String, String)>> {
+        let images = self.get_images(user_id)?;
+        let image = images.last().cloned();
+
+        Ok(image)
+    }
+
+    /// Return the most recently indexed self-assigned image reference for the
+    /// given public key.
+    fn get_latest_self_assigned_image(&self, user_id: &str) -> Result<Option<(String, String)>> {
+        let images = self.get_self_assigned_images(user_id)?;
+        let image = images.last().cloned();
+
+        Ok(image)
+    }
+
+    /// Add the given name to the name index for the associated public key.
+    fn index_name(&self, author_id: &str, about_id: &str, name: String) -> Result<()> {
+        // TODO: Do we also want to store the hash of the associated message?
+        let mut names = self.get_names(about_id)?;
+        names.push((author_id.to_owned(), name));
+        self.names.insert(about_id, serde_cbor::to_vec(&names)?)?;
+
+        Ok(())
+    }
+
+    /// Return all indexed names for the given public key.
+    fn get_names(&self, user_id: &str) -> Result<Vec<(String, String)>> {
+        let names = if let Some(raw) = self.names.get(user_id)? {
+            serde_cbor::from_slice::<Vec<(String, String)>>(&raw)?
+        } else {
+            Vec::new()
+        };
+
+        Ok(names)
+    }
+
+    /// Return all indexed self-assigned names for the given public key.
+    fn get_self_assigned_names(&self, user_id: &str) -> Result<Vec<(String, String)>> {
+        let mut names = self.get_names(user_id)?;
+        names.retain(|(author, _image)| author == user_id);
+
+        Ok(names)
+    }
+
+    /// Return the most recently indexed name for the given public key.
+    fn get_latest_name(&self, user_id: &str) -> Result<Option<(String, String)>> {
+        let names = self.get_names(user_id)?;
+        let name = names.last().cloned();
+
+        Ok(name)
+    }
+
+    /// Return the most recently indexed self-assigned name for the given public
+    /// key.
+    fn get_latest_self_assigned_name(&self, user_id: &str) -> Result<Option<(String, String)>> {
+        let names = self.get_self_assigned_names(user_id)?;
+        let name = names.last().cloned();
+
+        Ok(name)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use kuska_ssb::{
+        api::dto::content::{Image, TypedMessage},
+        feed::Message as MessageValue,
+        keystore::OwnedIdentity,
+    };
+    use serde_json::json;
+    use sled::Config;
+
+    use crate::secret_config::SecretConfig;
+    use crate::storage::kv::KvStorage;
+
+    fn open_temporary_kv() -> KvStorage {
+        let mut kv = KvStorage::default();
+        let (sender, _) = futures::channel::mpsc::unbounded();
+        let path = tempdir::TempDir::new("solardb").unwrap();
+        let config = Config::new().path(path.path());
+        kv.open(config, sender).unwrap();
+        kv
+    }
+
+    fn initialise_keypair_and_kv() -> (OwnedIdentity, KvStorage) {
+        // Create a unique keypair to sign messages.
+        let keypair = SecretConfig::create().to_owned_identity().unwrap();
+
+        // Open a temporary key-value store.
+        let kv = open_temporary_kv();
+
+        (keypair, kv)
+    }
+
+    #[async_std::test]
+    async fn test_about_indexes() -> Result<()> {
+        let (keypair, kv) = initialise_keypair_and_kv();
+        // TODO: Handle the unwrap.
+        let indexes = kv.indexes.as_ref().unwrap();
+
+        let first_name = "mycognosist".to_string();
+        let first_description = "just a humble fungi".to_string();
+        let image_ref = "&8M2JFEFHlxJ5q8Lmu3P4bDdCHg0SLB27Q321cy9Upx4=.sha256".to_string();
+
+        // Create an about-type message which assigns a name.
+        let first_msg_content = TypedMessage::About {
+            about: keypair.id.to_owned(),
+            name: Some(first_name.to_owned()),
+            branch: None,
+            description: Some(first_description.to_owned()),
+            image: Some(Image::OnlyLink(image_ref.to_owned())),
+            location: None,
+            start_datetime: None,
+            title: None,
+        };
+
+        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+        let first_msg =
+            MessageValue::sign(last_msg.as_ref(), &keypair, json!(first_msg_content)).unwrap();
+
+        indexes.index_msg(&keypair.id, first_msg)?;
+
+        if let Some((_author, description)) = indexes.get_latest_description(&keypair.id)? {
+            assert_eq!(description, first_description);
+        }
+
+        if let Some((_author, image)) = indexes.get_latest_image(&keypair.id)? {
+            assert_eq!(image, image_ref);
+        }
+
+        if let Some((_author, name)) = indexes.get_latest_name(&keypair.id)? {
+            assert_eq!(name, first_name);
+        }
+
+        let second_name = "glyph".to_string();
+        let second_description =
+            "[ sowing seeds of symbiosis | weaving webs of wu wei ]".to_string();
+
+        let second_msg_content = TypedMessage::About {
+            about: keypair.id.to_owned(),
+            name: Some(second_name.to_owned()),
+            branch: None,
+            description: Some(second_description.to_owned()),
+            image: None,
+            location: None,
+            start_datetime: None,
+            title: None,
+        };
+
+        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+        let second_msg =
+            MessageValue::sign(last_msg.as_ref(), &keypair, json!(second_msg_content)).unwrap();
+
+        indexes.index_msg(&keypair.id, second_msg)?;
+
+        if let Some((_author, lastest_name)) = indexes.get_latest_name(&keypair.id)? {
+            assert_eq!(lastest_name, second_name);
+        }
+
+        if let Some((_author, latest_description)) = indexes.get_latest_description(&keypair.id)? {
+            assert_eq!(latest_description, second_description);
+        }
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_channel_indexes() -> Result<()> {
+        let (keypair, kv) = initialise_keypair_and_kv();
+        // TODO: Handle the unwrap.
+        let indexes = kv.indexes.as_ref().unwrap();
+
+        let channel = "myco".to_string();
+        let subscribed = true;
+
+        // Create a channel-type message which subscribes to a channel.
+        let first_msg_content = TypedMessage::Channel {
+            channel: channel.to_owned(),
+            subscribed,
+        };
+
+        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+        let first_msg =
+            MessageValue::sign(last_msg.as_ref(), &keypair, json!(first_msg_content)).unwrap();
+
+        indexes.index_msg(&keypair.id, first_msg)?;
+
+        let subscribers = indexes.get_channel_subscribers(&channel)?;
+        assert!(subscribers.contains(&keypair.id));
+
+        let subscriptions = indexes.get_channel_subscriptions(&keypair.id)?;
+        assert!(subscriptions.contains(&channel));
+
+        // Create a channel-type message which unsubscribes to a channel.
+        let second_msg_content = TypedMessage::Channel {
+            channel: channel.to_owned(),
+            subscribed: false,
+        };
+
+        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+        let second_msg =
+            MessageValue::sign(last_msg.as_ref(), &keypair, json!(second_msg_content)).unwrap();
+
+        indexes.index_msg(&keypair.id, second_msg)?;
+
+        let subscribers = indexes.get_channel_subscribers(&channel)?;
+        assert!(!subscribers.contains(&keypair.id));
+
+        let subscriptions = indexes.get_channel_subscriptions(&keypair.id)?;
+        assert!(!subscriptions.contains(&channel));
+
+        Ok(())
+    }
+}

--- a/solar/src/storage/indexes.rs
+++ b/solar/src/storage/indexes.rs
@@ -586,9 +586,9 @@ mod test {
                 title: None,
             };
 
-            let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+            let last_msg = kv.get_latest_msg_val(&keypair.id)?;
             let first_msg =
-                MessageValue::sign(last_msg.as_ref(), &keypair, json!(first_msg_content)).unwrap();
+                MessageValue::sign(last_msg.as_ref(), &keypair, json!(first_msg_content))?;
 
             indexes.index_msg(&keypair.id, first_msg)?;
 
@@ -619,9 +619,9 @@ mod test {
                 title: None,
             };
 
-            let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+            let last_msg = kv.get_latest_msg_val(&keypair.id)?;
             let second_msg =
-                MessageValue::sign(last_msg.as_ref(), &keypair, json!(second_msg_content)).unwrap();
+                MessageValue::sign(last_msg.as_ref(), &keypair, json!(second_msg_content))?;
 
             indexes.index_msg(&keypair.id, second_msg)?;
 
@@ -653,10 +653,9 @@ mod test {
                 subscribed,
             };
 
-            let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+            let last_msg = kv.get_latest_msg_val(&keypair.id)?;
             let subscribe_msg =
-                MessageValue::sign(last_msg.as_ref(), &keypair, json!(subscribe_msg_content))
-                    .unwrap();
+                MessageValue::sign(last_msg.as_ref(), &keypair, json!(subscribe_msg_content))?;
 
             indexes.index_msg(&keypair.id, subscribe_msg)?;
 
@@ -672,10 +671,9 @@ mod test {
                 subscribed: false,
             };
 
-            let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+            let last_msg = kv.get_latest_msg_val(&keypair.id)?;
             let unsubscribe_msg =
-                MessageValue::sign(last_msg.as_ref(), &keypair, json!(unsubscribe_msg_content))
-                    .unwrap();
+                MessageValue::sign(last_msg.as_ref(), &keypair, json!(unsubscribe_msg_content))?;
 
             indexes.index_msg(&keypair.id, unsubscribe_msg)?;
 
@@ -703,9 +701,9 @@ mod test {
                 autofollow: None,
             };
 
-            let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+            let last_msg = kv.get_latest_msg_val(&keypair.id)?;
             let block_msg =
-                MessageValue::sign(last_msg.as_ref(), &keypair, json!(block_msg_content)).unwrap();
+                MessageValue::sign(last_msg.as_ref(), &keypair, json!(block_msg_content))?;
 
             indexes.index_msg(&keypair.id, block_msg)?;
 
@@ -729,10 +727,9 @@ mod test {
                 autofollow: None,
             };
 
-            let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+            let last_msg = kv.get_latest_msg_val(&keypair.id)?;
             let unblock_msg =
-                MessageValue::sign(last_msg.as_ref(), &keypair, json!(unblock_msg_content))
-                    .unwrap();
+                MessageValue::sign(last_msg.as_ref(), &keypair, json!(unblock_msg_content))?;
 
             indexes.index_msg(&keypair.id, unblock_msg)?;
 
@@ -760,13 +757,12 @@ mod test {
                 autofollow: None,
             };
 
-            let last_msg = kv.get_latest_msg_val(&blocked_keypair.id).unwrap();
+            let last_msg = kv.get_latest_msg_val(&blocked_keypair.id)?;
             let follow_back_msg = MessageValue::sign(
                 last_msg.as_ref(),
                 &blocked_keypair,
                 json!(follow_back_msg_content),
-            )
-            .unwrap();
+            )?;
 
             indexes.index_msg(&blocked_keypair.id, follow_back_msg)?;
 

--- a/solar/src/storage/indexes.rs
+++ b/solar/src/storage/indexes.rs
@@ -369,70 +369,72 @@ mod test {
     #[async_std::test]
     async fn test_about_indexes() -> Result<()> {
         let (keypair, kv) = initialise_keypair_and_kv();
-        // TODO: Handle the unwrap.
-        let indexes = kv.indexes.as_ref().unwrap();
 
-        let first_name = "mycognosist".to_string();
-        let first_description = "just a humble fungi".to_string();
-        let image_ref = "&8M2JFEFHlxJ5q8Lmu3P4bDdCHg0SLB27Q321cy9Upx4=.sha256".to_string();
+        if let Some(indexes) = kv.indexes.as_ref() {
+            let first_name = "mycognosist".to_string();
+            let first_description = "just a humble fungi".to_string();
+            let image_ref = "&8M2JFEFHlxJ5q8Lmu3P4bDdCHg0SLB27Q321cy9Upx4=.sha256".to_string();
 
-        // Create an about-type message which assigns a name.
-        let first_msg_content = TypedMessage::About {
-            about: keypair.id.to_owned(),
-            name: Some(first_name.to_owned()),
-            branch: None,
-            description: Some(first_description.to_owned()),
-            image: Some(Image::OnlyLink(image_ref.to_owned())),
-            location: None,
-            start_datetime: None,
-            title: None,
-        };
+            // Create an about-type message which assigns a name.
+            let first_msg_content = TypedMessage::About {
+                about: keypair.id.to_owned(),
+                name: Some(first_name.to_owned()),
+                branch: None,
+                description: Some(first_description.to_owned()),
+                image: Some(Image::OnlyLink(image_ref.to_owned())),
+                location: None,
+                start_datetime: None,
+                title: None,
+            };
 
-        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
-        let first_msg =
-            MessageValue::sign(last_msg.as_ref(), &keypair, json!(first_msg_content)).unwrap();
+            let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+            let first_msg =
+                MessageValue::sign(last_msg.as_ref(), &keypair, json!(first_msg_content)).unwrap();
 
-        indexes.index_msg(&keypair.id, first_msg)?;
+            indexes.index_msg(&keypair.id, first_msg)?;
 
-        if let Some((_author, description)) = indexes.get_latest_description(&keypair.id)? {
-            assert_eq!(description, first_description);
-        }
+            if let Some((_author, description)) = indexes.get_latest_description(&keypair.id)? {
+                assert_eq!(description, first_description);
+            }
 
-        if let Some((_author, image)) = indexes.get_latest_image(&keypair.id)? {
-            assert_eq!(image, image_ref);
-        }
+            if let Some((_author, image)) = indexes.get_latest_image(&keypair.id)? {
+                assert_eq!(image, image_ref);
+            }
 
-        if let Some((_author, name)) = indexes.get_latest_name(&keypair.id)? {
-            assert_eq!(name, first_name);
-        }
+            if let Some((_author, name)) = indexes.get_latest_name(&keypair.id)? {
+                assert_eq!(name, first_name);
+            }
 
-        let second_name = "glyph".to_string();
-        let second_description =
-            "[ sowing seeds of symbiosis | weaving webs of wu wei ]".to_string();
+            let second_name = "glyph".to_string();
+            let second_description =
+                "[ sowing seeds of symbiosis | weaving webs of wu wei ]".to_string();
 
-        let second_msg_content = TypedMessage::About {
-            about: keypair.id.to_owned(),
-            name: Some(second_name.to_owned()),
-            branch: None,
-            description: Some(second_description.to_owned()),
-            image: None,
-            location: None,
-            start_datetime: None,
-            title: None,
-        };
+            let second_msg_content = TypedMessage::About {
+                about: keypair.id.to_owned(),
+                name: Some(second_name.to_owned()),
+                branch: None,
+                description: Some(second_description.to_owned()),
+                image: None,
+                location: None,
+                start_datetime: None,
+                title: None,
+            };
 
-        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
-        let second_msg =
-            MessageValue::sign(last_msg.as_ref(), &keypair, json!(second_msg_content)).unwrap();
+            let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+            let second_msg =
+                MessageValue::sign(last_msg.as_ref(), &keypair, json!(second_msg_content)).unwrap();
 
-        indexes.index_msg(&keypair.id, second_msg)?;
+            indexes.index_msg(&keypair.id, second_msg)?;
 
-        if let Some((_author, lastest_name)) = indexes.get_latest_name(&keypair.id)? {
-            assert_eq!(lastest_name, second_name);
-        }
+            if let Some((_author, lastest_name)) = indexes.get_latest_name(&keypair.id)? {
+                assert_eq!(lastest_name, second_name);
+            }
 
-        if let Some((_author, latest_description)) = indexes.get_latest_description(&keypair.id)? {
-            assert_eq!(latest_description, second_description);
+            if let Some((_author, latest_description)) =
+                indexes.get_latest_description(&keypair.id)?
+            {
+                assert_eq!(latest_description, second_description);
+            }
         }
 
         Ok(())
@@ -441,47 +443,47 @@ mod test {
     #[async_std::test]
     async fn test_channel_indexes() -> Result<()> {
         let (keypair, kv) = initialise_keypair_and_kv();
-        // TODO: Handle the unwrap.
-        let indexes = kv.indexes.as_ref().unwrap();
 
-        let channel = "myco".to_string();
-        let subscribed = true;
+        if let Some(indexes) = kv.indexes.as_ref() {
+            let channel = "myco".to_string();
+            let subscribed = true;
 
-        // Create a channel-type message which subscribes to a channel.
-        let first_msg_content = TypedMessage::Channel {
-            channel: channel.to_owned(),
-            subscribed,
-        };
+            // Create a channel-type message which subscribes to a channel.
+            let first_msg_content = TypedMessage::Channel {
+                channel: channel.to_owned(),
+                subscribed,
+            };
 
-        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
-        let first_msg =
-            MessageValue::sign(last_msg.as_ref(), &keypair, json!(first_msg_content)).unwrap();
+            let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+            let first_msg =
+                MessageValue::sign(last_msg.as_ref(), &keypair, json!(first_msg_content)).unwrap();
 
-        indexes.index_msg(&keypair.id, first_msg)?;
+            indexes.index_msg(&keypair.id, first_msg)?;
 
-        let subscribers = indexes.get_channel_subscribers(&channel)?;
-        assert!(subscribers.contains(&keypair.id));
+            let subscribers = indexes.get_channel_subscribers(&channel)?;
+            assert!(subscribers.contains(&keypair.id));
 
-        let subscriptions = indexes.get_channel_subscriptions(&keypair.id)?;
-        assert!(subscriptions.contains(&channel));
+            let subscriptions = indexes.get_channel_subscriptions(&keypair.id)?;
+            assert!(subscriptions.contains(&channel));
 
-        // Create a channel-type message which unsubscribes to a channel.
-        let second_msg_content = TypedMessage::Channel {
-            channel: channel.to_owned(),
-            subscribed: false,
-        };
+            // Create a channel-type message which unsubscribes to a channel.
+            let second_msg_content = TypedMessage::Channel {
+                channel: channel.to_owned(),
+                subscribed: false,
+            };
 
-        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
-        let second_msg =
-            MessageValue::sign(last_msg.as_ref(), &keypair, json!(second_msg_content)).unwrap();
+            let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
+            let second_msg =
+                MessageValue::sign(last_msg.as_ref(), &keypair, json!(second_msg_content)).unwrap();
 
-        indexes.index_msg(&keypair.id, second_msg)?;
+            indexes.index_msg(&keypair.id, second_msg)?;
 
-        let subscribers = indexes.get_channel_subscribers(&channel)?;
-        assert!(!subscribers.contains(&keypair.id));
+            let subscribers = indexes.get_channel_subscribers(&channel)?;
+            assert!(!subscribers.contains(&keypair.id));
 
-        let subscriptions = indexes.get_channel_subscriptions(&keypair.id)?;
-        assert!(!subscriptions.contains(&channel));
+            let subscriptions = indexes.get_channel_subscriptions(&keypair.id)?;
+            assert!(!subscriptions.contains(&channel));
+        }
 
         Ok(())
     }

--- a/solar/src/storage/indexes.rs
+++ b/solar/src/storage/indexes.rs
@@ -545,28 +545,29 @@ mod test {
     use crate::secret_config::SecretConfig;
     use crate::storage::kv::KvStorage;
 
-    fn open_temporary_kv() -> KvStorage {
+    fn open_temporary_kv() -> Result<KvStorage> {
         let mut kv = KvStorage::default();
         let (sender, _) = futures::channel::mpsc::unbounded();
-        let path = tempdir::TempDir::new("solardb").unwrap();
+        let path = tempdir::TempDir::new("solardb")?;
         let config = Config::new().path(path.path());
-        kv.open(config, sender).unwrap();
-        kv
+        kv.open(config, sender)?;
+
+        Ok(kv)
     }
 
-    fn initialise_keypair_and_kv() -> (OwnedIdentity, KvStorage) {
+    fn initialise_keypair_and_kv() -> Result<(OwnedIdentity, KvStorage)> {
         // Create a unique keypair to sign messages.
-        let keypair = SecretConfig::create().to_owned_identity().unwrap();
+        let keypair = SecretConfig::create().to_owned_identity()?;
 
         // Open a temporary key-value store.
-        let kv = open_temporary_kv();
+        let kv = open_temporary_kv()?;
 
-        (keypair, kv)
+        Ok((keypair, kv))
     }
 
     #[async_std::test]
     async fn test_about_indexes() -> Result<()> {
-        let (keypair, kv) = initialise_keypair_and_kv();
+        let (keypair, kv) = initialise_keypair_and_kv()?;
 
         if let Some(indexes) = kv.indexes.as_ref() {
             let first_name = "mycognosist".to_string();
@@ -640,7 +641,7 @@ mod test {
 
     #[async_std::test]
     async fn test_channel_indexes() -> Result<()> {
-        let (keypair, kv) = initialise_keypair_and_kv();
+        let (keypair, kv) = initialise_keypair_and_kv()?;
 
         if let Some(indexes) = kv.indexes.as_ref() {
             let channel = "myco".to_string();
@@ -690,8 +691,8 @@ mod test {
 
     #[async_std::test]
     async fn test_contact_indexes() -> Result<()> {
-        let (keypair, kv) = initialise_keypair_and_kv();
-        let blocked_keypair = SecretConfig::create().to_owned_identity().unwrap();
+        let (keypair, kv) = initialise_keypair_and_kv()?;
+        let blocked_keypair = SecretConfig::create().to_owned_identity()?;
 
         if let Some(indexes) = kv.indexes.as_ref() {
             // Create a contact-type message which blocks an ID.

--- a/solar/src/storage/indexes.rs
+++ b/solar/src/storage/indexes.rs
@@ -135,7 +135,7 @@ impl Indexes {
 
     /// Return the public keys representing all peers blocked by the given
     /// public key.
-    fn get_blocks(&self, ssb_id: &str) -> Result<HashSet<String>> {
+    pub fn get_blocks(&self, ssb_id: &str) -> Result<HashSet<String>> {
         let blocks = if let Some(raw) = self.blocks.get(ssb_id)? {
             serde_cbor::from_slice::<HashSet<String>>(&raw)?
         } else {
@@ -164,7 +164,7 @@ impl Indexes {
 
     /// Return the public keys representing all peers blocking the given
     /// public key.
-    fn get_blockers(&self, ssb_id: &str) -> Result<HashSet<String>> {
+    pub fn get_blockers(&self, ssb_id: &str) -> Result<HashSet<String>> {
         let blockers = if let Some(raw) = self.blockers.get(ssb_id)? {
             serde_cbor::from_slice::<HashSet<String>>(&raw)?
         } else {
@@ -205,7 +205,7 @@ impl Indexes {
     }
 
     /// Return all subscribers of the given channel.
-    fn get_channel_subscribers(&self, channel: &str) -> Result<HashSet<String>> {
+    pub fn get_channel_subscribers(&self, channel: &str) -> Result<HashSet<String>> {
         let subscribers = if let Some(raw) = self.channel_subscribers.get(channel)? {
             serde_cbor::from_slice::<HashSet<String>>(&raw)?
         } else {
@@ -238,7 +238,7 @@ impl Indexes {
     }
 
     /// Return all the channel subscriptions for the given public key.
-    fn get_channel_subscriptions(&self, ssb_id: &str) -> Result<HashSet<String>> {
+    pub fn get_channel_subscriptions(&self, ssb_id: &str) -> Result<HashSet<String>> {
         let subscriptions = if let Some(raw) = self.channel_subscriptions.get(ssb_id)? {
             serde_cbor::from_slice::<HashSet<String>>(&raw)?
         } else {
@@ -285,7 +285,7 @@ impl Indexes {
     }
 
     /// Return all indexed descriptions for the given public key.
-    fn get_descriptions(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
+    pub fn get_descriptions(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
         let descriptions = if let Some(raw) = self.descriptions.get(ssb_id)? {
             serde_cbor::from_slice::<Vec<(String, String)>>(&raw)?
         } else {
@@ -296,7 +296,7 @@ impl Indexes {
     }
 
     /// Return all indexed self-assigned descriptions for the given public key.
-    fn get_self_assigned_descriptions(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
+    pub fn get_self_assigned_descriptions(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
         let mut descriptions = self.get_descriptions(ssb_id)?;
         descriptions.retain(|(author, _description)| author == ssb_id);
 
@@ -304,7 +304,7 @@ impl Indexes {
     }
 
     /// Return the most recently indexed description for the given public key.
-    fn get_latest_description(&self, ssb_id: &str) -> Result<Option<(String, String)>> {
+    pub fn get_latest_description(&self, ssb_id: &str) -> Result<Option<(String, String)>> {
         let descriptions = self.get_descriptions(ssb_id)?;
         let description = descriptions.last().cloned();
 
@@ -313,7 +313,7 @@ impl Indexes {
 
     /// Return the most recently indexed self-assigned description for the given
     /// public key.
-    fn get_latest_self_assigned_description(
+    pub fn get_latest_self_assigned_description(
         &self,
         ssb_id: &str,
     ) -> Result<Option<(String, String)>> {
@@ -351,7 +351,7 @@ impl Indexes {
 
     /// Return the public keys representing all peers followed by the given
     /// public key.
-    fn get_follows(&self, ssb_id: &str) -> Result<HashSet<String>> {
+    pub fn get_follows(&self, ssb_id: &str) -> Result<HashSet<String>> {
         let follows = if let Some(raw) = self.follows.get(ssb_id)? {
             serde_cbor::from_slice::<HashSet<String>>(&raw)?
         } else {
@@ -380,7 +380,7 @@ impl Indexes {
 
     /// Return the public keys representing all peers who follow the given
     /// public key.
-    fn get_followers(&self, ssb_id: &str) -> Result<HashSet<String>> {
+    pub fn get_followers(&self, ssb_id: &str) -> Result<HashSet<String>> {
         let followers = if let Some(raw) = self.followers.get(ssb_id)? {
             serde_cbor::from_slice::<HashSet<String>>(&raw)?
         } else {
@@ -391,7 +391,7 @@ impl Indexes {
     }
 
     /// Query whether or not the first given public key follows the second.
-    fn is_following(&self, peer_a: &str, peer_b: &str) -> Result<bool> {
+    pub fn is_following(&self, peer_a: &str, peer_b: &str) -> Result<bool> {
         let follows = self.get_follows(peer_a)?;
         let following = follows.contains(peer_b);
 
@@ -421,7 +421,7 @@ impl Indexes {
 
     /// Return the public keys representing all the friends (mutual follows)
     /// of the given public key.
-    fn get_friends(&self, ssb_id: &str) -> Result<HashSet<String>> {
+    pub fn get_friends(&self, ssb_id: &str) -> Result<HashSet<String>> {
         let friends = if let Some(raw) = self.friends.get(ssb_id)? {
             serde_cbor::from_slice::<HashSet<String>>(&raw)?
         } else {
@@ -445,7 +445,7 @@ impl Indexes {
     }
 
     /// Return all indexed image references for the given public key.
-    fn get_images(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
+    pub fn get_images(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
         let images = if let Some(raw) = self.images.get(ssb_id)? {
             serde_cbor::from_slice::<Vec<(String, String)>>(&raw)?
         } else {
@@ -457,7 +457,7 @@ impl Indexes {
 
     /// Return all indexed self-assigned image references for the given public
     /// key.
-    fn get_self_assigned_images(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
+    pub fn get_self_assigned_images(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
         let mut images = self.get_images(ssb_id)?;
         images.retain(|(author, _image)| author == ssb_id);
 
@@ -466,7 +466,7 @@ impl Indexes {
 
     /// Return the most recently indexed image reference for the given public
     /// key.
-    fn get_latest_image(&self, ssb_id: &str) -> Result<Option<(String, String)>> {
+    pub fn get_latest_image(&self, ssb_id: &str) -> Result<Option<(String, String)>> {
         let images = self.get_images(ssb_id)?;
         let image = images.last().cloned();
 
@@ -475,7 +475,7 @@ impl Indexes {
 
     /// Return the most recently indexed self-assigned image reference for the
     /// given public key.
-    fn get_latest_self_assigned_image(&self, ssb_id: &str) -> Result<Option<(String, String)>> {
+    pub fn get_latest_self_assigned_image(&self, ssb_id: &str) -> Result<Option<(String, String)>> {
         let images = self.get_self_assigned_images(ssb_id)?;
         let image = images.last().cloned();
 
@@ -493,7 +493,7 @@ impl Indexes {
     }
 
     /// Return all indexed names for the given public key.
-    fn get_names(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
+    pub fn get_names(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
         let names = if let Some(raw) = self.names.get(ssb_id)? {
             serde_cbor::from_slice::<Vec<(String, String)>>(&raw)?
         } else {
@@ -504,7 +504,7 @@ impl Indexes {
     }
 
     /// Return all indexed self-assigned names for the given public key.
-    fn get_self_assigned_names(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
+    pub fn get_self_assigned_names(&self, ssb_id: &str) -> Result<Vec<(String, String)>> {
         let mut names = self.get_names(ssb_id)?;
         names.retain(|(author, _image)| author == ssb_id);
 
@@ -512,7 +512,7 @@ impl Indexes {
     }
 
     /// Return the most recently indexed name for the given public key.
-    fn get_latest_name(&self, ssb_id: &str) -> Result<Option<(String, String)>> {
+    pub fn get_latest_name(&self, ssb_id: &str) -> Result<Option<(String, String)>> {
         let names = self.get_names(ssb_id)?;
         let name = names.last().cloned();
 
@@ -521,7 +521,7 @@ impl Indexes {
 
     /// Return the most recently indexed self-assigned name for the given public
     /// key.
-    fn get_latest_self_assigned_name(&self, ssb_id: &str) -> Result<Option<(String, String)>> {
+    pub fn get_latest_self_assigned_name(&self, ssb_id: &str) -> Result<Option<(String, String)>> {
         let names = self.get_self_assigned_names(ssb_id)?;
         let name = names.last().cloned();
 

--- a/solar/src/storage/kv.rs
+++ b/solar/src/storage/kv.rs
@@ -276,14 +276,14 @@ impl KvStorage {
         // list of peers.
         self.set_peer(&author, seq_num).await?;
 
+        // Pass the message to the indexer.
+        self.index_msg(msg_val)?;
+
         db.flush_async().await?;
 
         // Publish a notification that the feed belonging to the given public
         // key has been updated.
-        let broker_msg = BrokerEvent::new(
-            Destination::Broadcast,
-            StoKvEvent::IdChanged(msg_val.author().clone()),
-        );
+        let broker_msg = BrokerEvent::new(Destination::Broadcast, StoKvEvent::IdChanged(author));
 
         // Matching on the error here (instead of unwrapping) allows us to
         // write unit tests for `append_feed`; a case where we do not have

--- a/solar/src/storage/kv.rs
+++ b/solar/src/storage/kv.rs
@@ -1,16 +1,13 @@
-use std::collections::HashSet;
-
 use futures::SinkExt;
-use kuska_ssb::{
-    api::dto::content::{Image, TypedMessage as MessageContent},
-    feed::{Feed as MessageKvt, Message as MessageValue},
-};
+use kuska_ssb::feed::{Feed as MessageKvt, Message as MessageValue};
 use log::warn;
 use serde::{Deserialize, Serialize};
+use sled::{Config as DbConfig, Db};
 
 use crate::{
     broker::{BrokerEvent, ChBrokerSend, Destination},
     error::Error,
+    storage::indexes::Indexes,
     Result,
 };
 
@@ -51,19 +48,9 @@ pub struct PubKeyAndSeqNum {
 #[derive(Default)]
 pub struct KvStorage {
     /// The core database which stores messages and blob references.
-    db: Option<sled::Db>,
-    // TODO: Move indexes into a separate module and organise them into a
-    // standalone struct.
-    /// Channel subscriber indexes stored in a database tree.
-    channel_subscriber_index: Option<sled::Tree>,
-    /// Channel subscription indexes stored in a database tree.
-    channel_subscription_index: Option<sled::Tree>,
-    /// Description indexes stored in a database tree.
-    description_index: Option<sled::Tree>,
-    /// Image reference indexes stored in a database tree.
-    image_index: Option<sled::Tree>,
-    /// Name indexes stored in a database tree.
-    name_index: Option<sled::Tree>,
+    db: Option<Db>,
+    /// Indexes to allow for efficient database value look-ups.
+    pub indexes: Option<Indexes>,
     /// A message-passing sender.
     ch_broker: Option<ChBrokerSend>,
 }
@@ -72,20 +59,12 @@ impl KvStorage {
     /// Open the key-value database using the given configuration, open the
     /// database index trees and populate the instance of `KvStorage`
     /// with the database, indexes and message-passing sender.
-    pub fn open(&mut self, config: sled::Config, ch_broker: ChBrokerSend) -> Result<()> {
+    pub fn open(&mut self, config: DbConfig, ch_broker: ChBrokerSend) -> Result<()> {
         let db = config.open()?;
-        let channel_subscriber_index = db.open_tree("channel_subscriber")?;
-        let channel_subscription_index = db.open_tree("channel_subscription")?;
-        let description_index = db.open_tree("description")?;
-        let image_index = db.open_tree("image")?;
-        let name_index = db.open_tree("name")?;
+        let indexes = Indexes::open(&db)?;
 
         self.db = Some(db);
-        self.channel_subscriber_index = Some(channel_subscriber_index);
-        self.channel_subscription_index = Some(channel_subscription_index);
-        self.description_index = Some(description_index);
-        self.image_index = Some(image_index);
-        self.name_index = Some(name_index);
+        self.indexes = Some(indexes);
         self.ch_broker = Some(ch_broker);
 
         Ok(())
@@ -297,7 +276,9 @@ impl KvStorage {
         self.set_peer(&author, seq_num).await?;
 
         // Pass the author and message value to the indexer.
-        self.index_msg(&author, msg_val)?;
+        if let Some(indexes) = &self.indexes {
+            indexes.index_msg(&author, msg_val)?
+        }
 
         db.flush_async().await?;
 
@@ -316,302 +297,6 @@ impl KvStorage {
         };
 
         Ok(seq_num)
-    }
-
-    /// Index a message based on the author (SSB ID) and content type.
-    fn index_msg(&self, author: &str, msg_val: MessageValue) -> Result<()> {
-        if let Some(content_val) = msg_val.value.get("content") {
-            let content: MessageContent = serde_json::from_value(content_val.to_owned())?;
-
-            match content {
-                MessageContent::About { .. } => self.index_about(author, content)?,
-                MessageContent::Channel {
-                    channel,
-                    subscribed,
-                } => self.index_channel(author, channel, subscribed)?,
-                _ => (),
-            }
-        }
-
-        Ok(())
-    }
-
-    // TODO: We need to also pass in the message author and include that
-    // data in the index. This is in order to know whom the about message
-    // was created by. Ie. is it self-description (updating one's own profile)
-    // or description of another?
-    /// Index the content of an about-type message.
-    fn index_about(&self, user_id: &str, msg_content: MessageContent) -> Result<()> {
-        // Match on each field of an about-type message and call each individual
-        // indexer as required. This allows us to catch the possibility that
-        // multiple fields are set in a single message (such as name and
-        // description).
-        if let MessageContent::About {
-            about,
-            description,
-            image,
-            name,
-            ..
-        } = msg_content
-        {
-            if let Some(description) = description {
-                self.index_description(user_id, &about, description)?
-            }
-            if let Some(image) = image {
-                self.index_image(user_id, &about, image)?
-            }
-            if let Some(name) = name {
-                self.index_name(user_id, &about, name)?
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Add the given channel to the channel index.
-    fn index_channel(&self, user_id: &str, channel: String, subscribed: bool) -> Result<()> {
-        self.index_channel_subscriber(user_id, &channel, subscribed)?;
-        self.index_channel_subscription(user_id, &channel, subscribed)?;
-
-        Ok(())
-    }
-
-    /// Update the channel subscribers index for the given public key, channel
-    /// and subscription state.
-    fn index_channel_subscriber(
-        &self,
-        user_id: &str,
-        channel: &str,
-        subscribed: bool,
-    ) -> Result<()> {
-        let channel_subscriber_index = self.channel_subscriber_index.as_ref().unwrap();
-        let mut subscribers = self.get_channel_subscribers(channel)?;
-
-        if subscribed {
-            subscribers.insert(user_id.to_owned());
-        } else {
-            subscribers.remove(user_id);
-        }
-
-        channel_subscriber_index.insert(channel, serde_cbor::to_vec(&subscribers)?)?;
-
-        Ok(())
-    }
-
-    /// Return all subscribers of the given channel.
-    fn get_channel_subscribers(&self, channel: &str) -> Result<HashSet<String>> {
-        let channel_subscriber_index = self.channel_subscriber_index.as_ref().unwrap();
-
-        // Return and deserialize the channel subscribers indexed by the
-        // given channel.
-        let subscribers = if let Some(raw) = channel_subscriber_index.get(channel)? {
-            serde_cbor::from_slice::<HashSet<String>>(&raw)?
-        } else {
-            HashSet::new()
-        };
-
-        Ok(subscribers)
-    }
-
-    /// Update the channel subscription index for the given public key, channel
-    /// and subscription state.
-    fn index_channel_subscription(
-        &self,
-        user_id: &str,
-        channel: &str,
-        subscribed: bool,
-    ) -> Result<()> {
-        let channel_subscription_index = self.channel_subscription_index.as_ref().unwrap();
-        let mut subscriptions = self.get_channel_subscriptions(user_id)?;
-
-        if subscribed {
-            subscriptions.insert(channel.to_owned());
-        } else {
-            subscriptions.remove(channel);
-        }
-
-        channel_subscription_index.insert(user_id, serde_cbor::to_vec(&subscriptions)?)?;
-
-        Ok(())
-    }
-
-    /// Return all the channel subscriptions for the given public key.
-    fn get_channel_subscriptions(&self, user_id: &str) -> Result<HashSet<String>> {
-        let channel_subscription_index = self.channel_subscription_index.as_ref().unwrap();
-
-        // Return and deserialize the channel subscriptions indexed by the
-        // given public key.
-        let subscriptions = if let Some(raw) = channel_subscription_index.get(user_id)? {
-            serde_cbor::from_slice::<HashSet<String>>(&raw)?
-        } else {
-            HashSet::new()
-        };
-
-        Ok(subscriptions)
-    }
-
-    /// Add the given description to the description index for the associated
-    /// public key.
-    fn index_description(
-        &self,
-        author_id: &str,
-        about_id: &str,
-        description: String,
-    ) -> Result<()> {
-        let description_index = self.description_index.as_ref().unwrap();
-        let mut descriptions = self.get_descriptions(about_id)?;
-        descriptions.push((author_id.to_owned(), description));
-        description_index.insert(about_id, serde_cbor::to_vec(&descriptions)?)?;
-
-        Ok(())
-    }
-
-    /// Return all indexed descriptions for the given public key.
-    fn get_descriptions(&self, user_id: &str) -> Result<Vec<(String, String)>> {
-        let description_index = self.description_index.as_ref().unwrap();
-
-        // Return and deserialize the descriptions indexed by the given SSB ID.
-        let descriptions = if let Some(raw) = description_index.get(user_id)? {
-            serde_cbor::from_slice::<Vec<(String, String)>>(&raw)?
-        } else {
-            Vec::new()
-        };
-
-        Ok(descriptions)
-    }
-
-    /// Return all indexed self-assigned descriptions for the given public key.
-    fn get_self_assigned_descriptions(&self, user_id: &str) -> Result<Vec<(String, String)>> {
-        let mut descriptions = self.get_descriptions(user_id)?;
-        descriptions.retain(|(author, _description)| author == user_id);
-
-        Ok(descriptions)
-    }
-
-    /// Return the most recently indexed description for the given public key.
-    fn get_latest_description(&self, user_id: &str) -> Result<Option<(String, String)>> {
-        let descriptions = self.get_descriptions(user_id)?;
-        let description = descriptions.last().cloned();
-
-        Ok(description)
-    }
-
-    /// Return the most recently indexed self-assigned description for the given
-    /// public key.
-    fn get_latest_self_assigned_description(
-        &self,
-        user_id: &str,
-    ) -> Result<Option<(String, String)>> {
-        let self_descriptions = self.get_self_assigned_descriptions(user_id)?;
-        let description = self_descriptions.last().cloned();
-
-        Ok(description)
-    }
-
-    /// Add the given image reference to the image index for the associated
-    /// public key.
-    fn index_image(&self, author_id: &str, about_id: &str, image: Image) -> Result<()> {
-        // TODO: Handle `Image::Complete { .. }` variant.
-        if let Image::OnlyLink(ssb_hash) = image {
-            let image_index = self.image_index.as_ref().unwrap();
-            let mut images = self.get_images(about_id)?;
-            images.push((author_id.to_owned(), ssb_hash));
-            image_index.insert(about_id, serde_cbor::to_vec(&images)?)?;
-        }
-
-        Ok(())
-    }
-
-    /// Return all indexed image references for the given public key.
-    fn get_images(&self, user_id: &str) -> Result<Vec<(String, String)>> {
-        let image_index = self.image_index.as_ref().unwrap();
-
-        // Return and deserialize the image references indexed by the given
-        // SSB ID.
-        let images = if let Some(raw) = image_index.get(user_id)? {
-            serde_cbor::from_slice::<Vec<(String, String)>>(&raw)?
-        } else {
-            Vec::new()
-        };
-
-        Ok(images)
-    }
-
-    /// Return all indexed self-assigned image references for the given public
-    /// key.
-    fn get_self_assigned_images(&self, user_id: &str) -> Result<Vec<(String, String)>> {
-        let mut images = self.get_images(user_id)?;
-        images.retain(|(author, _image)| author == user_id);
-
-        Ok(images)
-    }
-
-    /// Return the most recently indexed image reference for the given public
-    /// key.
-    fn get_latest_image(&self, user_id: &str) -> Result<Option<(String, String)>> {
-        let images = self.get_images(user_id)?;
-        let image = images.last().cloned();
-
-        Ok(image)
-    }
-
-    /// Return the most recently indexed self-assigned image reference for the
-    /// given public key.
-    fn get_latest_self_assigned_image(&self, user_id: &str) -> Result<Option<(String, String)>> {
-        let images = self.get_self_assigned_images(user_id)?;
-        let image = images.last().cloned();
-
-        Ok(image)
-    }
-
-    /// Add the given name to the name index for the associated public key.
-    fn index_name(&self, author_id: &str, about_id: &str, name: String) -> Result<()> {
-        // TODO: Do we also want to store the hash of the associated message?
-        let name_index = self.name_index.as_ref().unwrap();
-        let mut names = self.get_names(about_id)?;
-        names.push((author_id.to_owned(), name));
-        name_index.insert(about_id, serde_cbor::to_vec(&names)?)?;
-
-        Ok(())
-    }
-
-    /// Return all indexed names for the given public key.
-    fn get_names(&self, user_id: &str) -> Result<Vec<(String, String)>> {
-        let name_index = self.name_index.as_ref().unwrap();
-
-        // Return and deserialize the names indexed by the given SSB ID.
-        let names = if let Some(raw) = name_index.get(user_id)? {
-            serde_cbor::from_slice::<Vec<(String, String)>>(&raw)?
-        } else {
-            Vec::new()
-        };
-
-        Ok(names)
-    }
-
-    /// Return all indexed self-assigned names for the given public key.
-    fn get_self_assigned_names(&self, user_id: &str) -> Result<Vec<(String, String)>> {
-        let mut names = self.get_names(user_id)?;
-        names.retain(|(author, _image)| author == user_id);
-
-        Ok(names)
-    }
-
-    /// Return the most recently indexed name for the given public key.
-    fn get_latest_name(&self, user_id: &str) -> Result<Option<(String, String)>> {
-        let names = self.get_names(user_id)?;
-        let name = names.last().cloned();
-
-        Ok(name)
-    }
-
-    /// Return the most recently indexed self-assigned name for the given public
-    /// key.
-    fn get_latest_self_assigned_name(&self, user_id: &str) -> Result<Option<(String, String)>> {
-        let names = self.get_self_assigned_names(user_id)?;
-        let name = names.last().cloned();
-
-        Ok(name)
     }
 
     /// Get all messages comprising the feed authored by the given public key.
@@ -641,7 +326,7 @@ mod test {
 
     use kuska_ssb::{api::dto::content::TypedMessage, keystore::OwnedIdentity};
     use serde_json::json;
-    use sled::Config as KvConfig;
+    use sled::Config;
 
     use crate::secret_config::SecretConfig;
 
@@ -649,7 +334,7 @@ mod test {
         let mut kv = KvStorage::default();
         let (sender, _) = futures::channel::mpsc::unbounded();
         let path = tempdir::TempDir::new("solardb").unwrap();
-        let config = KvConfig::new().path(path.path());
+        let config = Config::new().path(path.path());
         kv.open(config, sender).unwrap();
         kv
     }
@@ -662,117 +347,6 @@ mod test {
         let kv = open_temporary_kv();
 
         (keypair, kv)
-    }
-
-    #[async_std::test]
-    async fn test_about_indexes() -> Result<()> {
-        let (keypair, kv) = initialise_keypair_and_kv();
-
-        let first_name = "mycognosist".to_string();
-        let first_description = "just a humble fungi".to_string();
-        let image_ref = "&8M2JFEFHlxJ5q8Lmu3P4bDdCHg0SLB27Q321cy9Upx4=.sha256".to_string();
-
-        // Create an about-type message which assigns a name.
-        let first_msg_content = TypedMessage::About {
-            about: keypair.id.to_owned(),
-            name: Some(first_name.to_owned()),
-            branch: None,
-            description: Some(first_description.to_owned()),
-            image: Some(Image::OnlyLink(image_ref.to_owned())),
-            location: None,
-            start_datetime: None,
-            title: None,
-        };
-
-        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
-        let first_msg =
-            MessageValue::sign(last_msg.as_ref(), &keypair, json!(first_msg_content)).unwrap();
-
-        kv.index_msg(&keypair.id, first_msg)?;
-
-        let description = kv.get_description(&keypair.id)?;
-        assert_eq!(description, Some(first_description));
-
-        let image = kv.get_image(&keypair.id)?;
-        assert_eq!(image, Some(image_ref));
-
-        let name = kv.get_name(&keypair.id)?;
-        assert_eq!(name, Some(first_name));
-
-        let second_name = "glyph".to_string();
-        let second_description =
-            "[ sowing seeds of symbiosis | weaving webs of wu wei ]".to_string();
-
-        let second_msg_content = TypedMessage::About {
-            about: keypair.id.to_owned(),
-            name: Some(second_name.to_owned()),
-            branch: None,
-            description: Some(second_description.to_owned()),
-            image: None,
-            location: None,
-            start_datetime: None,
-            title: None,
-        };
-
-        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
-        let second_msg =
-            MessageValue::sign(last_msg.as_ref(), &keypair, json!(second_msg_content)).unwrap();
-
-        kv.index_msg(&keypair.id, second_msg)?;
-
-        let lastest_name = kv.get_name(&keypair.id)?;
-        assert_eq!(lastest_name, Some(second_name));
-
-        let latest_description = kv.get_description(&keypair.id)?;
-        assert_eq!(latest_description, Some(second_description));
-
-        Ok(())
-    }
-
-    #[async_std::test]
-    async fn test_channel_indexes() -> Result<()> {
-        let (keypair, kv) = initialise_keypair_and_kv();
-
-        let channel = "myco".to_string();
-        let subscribed = true;
-
-        // Create a channel-type message which subscribes to a channel.
-        let first_msg_content = TypedMessage::Channel {
-            channel: channel.to_owned(),
-            subscribed,
-        };
-
-        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
-        let first_msg =
-            MessageValue::sign(last_msg.as_ref(), &keypair, json!(first_msg_content)).unwrap();
-
-        kv.index_msg(&keypair.id, first_msg)?;
-
-        let subscribers = kv.get_channel_subscribers(&channel)?;
-        assert!(subscribers.contains(&keypair.id));
-
-        let subscriptions = kv.get_channel_subscriptions(&keypair.id)?;
-        assert!(subscriptions.contains(&channel));
-
-        // Create a channel-type message which unsubscribes to a channel.
-        let second_msg_content = TypedMessage::Channel {
-            channel: channel.to_owned(),
-            subscribed: false,
-        };
-
-        let last_msg = kv.get_latest_msg_val(&keypair.id).unwrap();
-        let second_msg =
-            MessageValue::sign(last_msg.as_ref(), &keypair, json!(second_msg_content)).unwrap();
-
-        kv.index_msg(&keypair.id, second_msg)?;
-
-        let subscribers = kv.get_channel_subscribers(&channel)?;
-        assert!(!subscribers.contains(&keypair.id));
-
-        let subscriptions = kv.get_channel_subscriptions(&keypair.id)?;
-        assert!(!subscriptions.contains(&channel));
-
-        Ok(())
     }
 
     #[async_std::test]

--- a/solar/src/storage/mod.rs
+++ b/solar/src/storage/mod.rs
@@ -1,2 +1,3 @@
 pub mod blob;
+pub mod indexes;
 pub mod kv;


### PR DESCRIPTION
This PR is the result of an exploration into database indexes for common SSB message content types and data. While I initially felt that it might be best to keep index creation separate from `solar`, I realise that such an approach will likely decrease the chance of others using the software to develop their own client. If this turns out to be a bad idea, at least the `index` module is sufficiently encapsulated and can easily be split-off.

Each message is indexed immediately after having been appended to the database.

A next step would be to expose the index getter methods via JSON-RPC. It may also be worthwhile to consider approaches for validating, wiping / resetting and reindexing.

## Methods

```rust
get_blocks(ssb_id)
get_blockers(ssb_id)
get_channel_subscribers(channel)
get_channel_subscriptions(ssb_id)
get_descriptions(ssb_id)
get_self_assigned_descriptions(ssb_id)
get_latest_description(ssb_id)
get_latest_self_assigned_description(ssb_id)
get_follows(ssb_id)
get_followers(ssb_id)
is_following(peer_a, peer_b)
get_friends(ssb_id)
get_images(ssb_id)
get_self_assigned_images(ssb_id)
get_latest_image(ssb_id)
get_latest_self_assigned_image(ssb_id)
get_names(ssb_id)
get_self_assigned_names(ssb_id)
get_latest_name(ssb_id)
get_latest_self_assigned_name(ssb_id)
```