### PR TITLE
Expose database indexes via JSON-RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,31 @@ While running, a solar node can be queried using JSON-RPC over HTTP.
 
 | Method | Parameters | Response | Description |
 | --- | --- | --- | --- |
-| `feed` | `{ "pub_key": "<@...=.ed25519>" }` | `[{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }]` | Return an array of message KVTs (key, value, timestamp) from the local database |
-| `message` | `{ "msg_ref": <key> }` | `{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }` | Return a single message KVT (key, value, timestamp) from the local database |
-| `peers` | | `[{ "pub_key": "<@...=.ed25519>", "seq_num": <int> }` | Return the public key and latest sequence number for all peers in the local database |
+| `blocks` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `blockers` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `descriptions` | `"<@...=.ed25519>"` | `[<description>]` | Returns an array of descriptions |
+| `self_descriptions` | `"<@...=.ed25519>"` | `[<description>]` | Returns an array of descriptions |
+| `latest_description` | `"<@...=.ed25519>"` | `<description>` | Returns a single description |
+| `latest_self_description` | `"<@...=.ed25519>"` | `<description>` | Returns a single description |
+| `feed` | `"<@...=.ed25519>"` | `[{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }]` | Returns an array of message KVTs (key, value, timestamp) from the local database |
+| `follows` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `followers` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `is_following` | `{ "peer_a": "<@...=.ed25519>", "peer_b": "<@...=.ed25519>" }` | `[<@...=.ed25519>]` | Returns a boolean |
+| `friends` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `images` | `"<@...=.ed25519>"` | `[<&...=.sha256>]` | Returns an array of image references |
+| `self_images` | `"<@...=.ed25519>"` | `[<&...=.sha256>]` | Returns an array of image references |
+| `latest_image` | `"<@...=.ed25519>"` | `<&...=.sha256>` | Returns a single image reference |
+| `latest_self_image` | `"<@...=.ed25519>"` | `<&...=.sha256>` | Returns a single image reference |
+| `message` | `"<%...=.sha256>"` | `{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }` | Returns a single message KVT (key, value, timestamp) from the local database |
+| `names` | `"<@...=.ed25519>"` | `[<name>]` | Returns an array of names |
+| `self_names` | `"<@...=.ed25519>"` | `[<name>]` | Returns an array of names |
+| `latest_name` | `"<@...=.ed25519>"` | `<name>` | Returns a single name |
+| `latest_self_name` | `"<@...=.ed25519>"` | `<name>` | Returns a single name |
+| `peers` | | `[{ "pub_key": "<@...=.ed25519>", "seq_num": <int> }` | Returns an array of public key and latest sequence number for each peer in the local database |
 | `ping` | | `pong!` | Responds if the JSON-RPC server is running |
 | `publish` | `<content>` | `{ "msg_ref": "<%...=.sha256>", "seq_num": <int> }` | Publishes a message and returns the reference (message hash) and sequence number |
+| `subscribers` | `"<channel>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `subscriptions` | `"<@...=.ed25519>"` | `[<channel>]` | Returns an array of channel names |
 | `whoami` | | `<@...=.ed25519>` | Returns the public key of the local node |
 
 ### Examples

--- a/solar/README.md
+++ b/solar/README.md
@@ -67,11 +67,31 @@ While running, a solar node can be queried using JSON-RPC over HTTP.
 
 | Method | Parameters | Response | Description |
 | --- | --- | --- | --- |
-| `feed` | `{ "pub_key": "<@...=.ed25519>" }` | `[{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }]` | Return an array of message KVTs (key, value, timestamp) from the local database |
-| `message` | `{ "msg_ref": <key> }` | `{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }` | Return a single message KVT (key, value, timestamp) from the local database |
-| `peers` | | `[{ "pub_key": "<@...=.ed25519>", "seq_num": <int> }` | Return the public key and latest sequence number for all peers in the local database |
+| `blocks` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `blockers` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `descriptions` | `"<@...=.ed25519>"` | `[<description>]` | Returns an array of descriptions |
+| `self_descriptions` | `"<@...=.ed25519>"` | `[<description>]` | Returns an array of descriptions |
+| `latest_description` | `"<@...=.ed25519>"` | `<description>` | Returns a single description |
+| `latest_self_description` | `"<@...=.ed25519>"` | `<description>` | Returns a single description |
+| `feed` | `"<@...=.ed25519>"` | `[{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }]` | Returns an array of message KVTs (key, value, timestamp) from the local database |
+| `follows` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `followers` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `is_following` | `{ "peer_a": "<@...=.ed25519>", "peer_b": "<@...=.ed25519>" }` | `[<@...=.ed25519>]` | Returns a boolean |
+| `friends` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `images` | `"<@...=.ed25519>"` | `[<&...=.sha256>]` | Returns an array of image references |
+| `self_images` | `"<@...=.ed25519>"` | `[<&...=.sha256>]` | Returns an array of image references |
+| `latest_image` | `"<@...=.ed25519>"` | `<&...=.sha256>` | Returns a single image reference |
+| `latest_self_image` | `"<@...=.ed25519>"` | `<&...=.sha256>` | Returns a single image reference |
+| `message` | `"<%...=.sha256>"` | `{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }` | Returns a single message KVT (key, value, timestamp) from the local database |
+| `names` | `"<@...=.ed25519>"` | `[<name>]` | Returns an array of names |
+| `self_names` | `"<@...=.ed25519>"` | `[<name>]` | Returns an array of names |
+| `latest_name` | `"<@...=.ed25519>"` | `<name>` | Returns a single name |
+| `latest_self_name` | `"<@...=.ed25519>"` | `<name>` | Returns a single name |
+| `peers` | | `[{ "pub_key": "<@...=.ed25519>", "seq_num": <int> }` | Returns an array of public key and latest sequence number for each peer in the local database |
 | `ping` | | `pong!` | Responds if the JSON-RPC server is running |
 | `publish` | `<content>` | `{ "msg_ref": "<%...=.sha256>", "seq_num": <int> }` | Publishes a message and returns the reference (message hash) and sequence number |
+| `subscribers` | `"<channel>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `subscriptions` | `"<@...=.ed25519>"` | `[<channel>]` | Returns an array of channel names |
 | `whoami` | | `<@...=.ed25519>` | Returns the public key of the local node |
 
 ### Examples

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -183,6 +183,29 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the public keys of all feeds followed by the given public key.
+    //
+    // Returns an array of public keys.
+    rpc_module.register_method("follows", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            if let Some(indexes) = &db.indexes {
+                let follows = indexes.get_follows(&pub_key.0)?;
+                let response = json!(follows);
+
+                Ok::<Value, JsonRpcError>(response)
+            } else {
+                let empty_vec: Vec<String> = Vec::new();
+                let response = json!(empty_vec);
+
+                Ok::<Value, JsonRpcError>(response)
+            }
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -242,6 +242,23 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the self-assigned image references for the given public key.
+    //
+    // Returns an array of strings.
+    rpc_module.register_method("self_images", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let images = indexes.get_self_assigned_images(&pub_key.0)?;
+            let response = json!(images);
+
+            Ok::<Value, JsonRpcError>(response)
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -160,6 +160,29 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the latest (most-recent) self-assigned description for the given
+    // public key.
+    //
+    // Returns a string.
+    rpc_module.register_method("latest_self_description", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            if let Some(indexes) = &db.indexes {
+                let description = indexes.get_latest_self_assigned_description(&pub_key.0)?;
+                let response = json!(description);
+
+                Ok::<Value, JsonRpcError>(response)
+            } else {
+                let response = json!(String::new());
+
+                Ok::<Value, JsonRpcError>(response)
+            }
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -207,6 +207,24 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the public keys of all friends (mutual follows) of the given
+    // public key.
+    //
+    // Returns an array of public keys.
+    rpc_module.register_method("friends", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let friends = indexes.get_friends(&pub_key.0)?;
+            let response = json!(friends);
+
+            Ok::<Value, JsonRpcError>(response)
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -23,6 +23,13 @@ struct MsgRef(String);
 #[derive(Debug, Deserialize)]
 struct PubKey(String);
 
+/// The public keys (ID) of two peers.
+#[derive(Debug, Deserialize)]
+struct IsFollowing {
+    peer_a: String,
+    peer_b: String,
+}
+
 /// Register the JSON-RPC server endpoint, define the JSON-RPC methods
 /// and spawn the server.
 ///
@@ -55,17 +62,11 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
             // Open the primary KV database for reading.
             let db = KV_STORE.read().await;
 
-            if let Some(indexes) = &db.indexes {
-                let blocks = indexes.get_blocks(&pub_key.0)?;
-                let response = json!(blocks);
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let blocks = indexes.get_blocks(&pub_key.0)?;
+            let response = json!(blocks);
 
-                Ok::<Value, JsonRpcError>(response)
-            } else {
-                let empty_vec: Vec<String> = Vec::new();
-                let response = json!(empty_vec);
-
-                Ok::<Value, JsonRpcError>(response)
-            }
+            Ok::<Value, JsonRpcError>(response)
         })
     })?;
 
@@ -78,17 +79,11 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
 
             let db = KV_STORE.read().await;
 
-            if let Some(indexes) = &db.indexes {
-                let blockers = indexes.get_blockers(&pub_key.0)?;
-                let response = json!(blockers);
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let blockers = indexes.get_blockers(&pub_key.0)?;
+            let response = json!(blockers);
 
-                Ok::<Value, JsonRpcError>(response)
-            } else {
-                let empty_vec: Vec<String> = Vec::new();
-                let response = json!(empty_vec);
-
-                Ok::<Value, JsonRpcError>(response)
-            }
+            Ok::<Value, JsonRpcError>(response)
         })
     })?;
 
@@ -101,17 +96,11 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
 
             let db = KV_STORE.read().await;
 
-            if let Some(indexes) = &db.indexes {
-                let descriptions = indexes.get_descriptions(&pub_key.0)?;
-                let response = json!(descriptions);
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let descriptions = indexes.get_descriptions(&pub_key.0)?;
+            let response = json!(descriptions);
 
-                Ok::<Value, JsonRpcError>(response)
-            } else {
-                let empty_vec: Vec<String> = Vec::new();
-                let response = json!(empty_vec);
-
-                Ok::<Value, JsonRpcError>(response)
-            }
+            Ok::<Value, JsonRpcError>(response)
         })
     })?;
 
@@ -124,17 +113,11 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
 
             let db = KV_STORE.read().await;
 
-            if let Some(indexes) = &db.indexes {
-                let descriptions = indexes.get_self_assigned_descriptions(&pub_key.0)?;
-                let response = json!(descriptions);
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let descriptions = indexes.get_self_assigned_descriptions(&pub_key.0)?;
+            let response = json!(descriptions);
 
-                Ok::<Value, JsonRpcError>(response)
-            } else {
-                let empty_vec: Vec<String> = Vec::new();
-                let response = json!(empty_vec);
-
-                Ok::<Value, JsonRpcError>(response)
-            }
+            Ok::<Value, JsonRpcError>(response)
         })
     })?;
 
@@ -147,16 +130,11 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
 
             let db = KV_STORE.read().await;
 
-            if let Some(indexes) = &db.indexes {
-                let description = indexes.get_latest_description(&pub_key.0)?;
-                let response = json!(description);
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let description = indexes.get_latest_description(&pub_key.0)?;
+            let response = json!(description);
 
-                Ok::<Value, JsonRpcError>(response)
-            } else {
-                let response = json!(String::new());
-
-                Ok::<Value, JsonRpcError>(response)
-            }
+            Ok::<Value, JsonRpcError>(response)
         })
     })?;
 
@@ -170,16 +148,11 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
 
             let db = KV_STORE.read().await;
 
-            if let Some(indexes) = &db.indexes {
-                let description = indexes.get_latest_self_assigned_description(&pub_key.0)?;
-                let response = json!(description);
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let description = indexes.get_latest_self_assigned_description(&pub_key.0)?;
+            let response = json!(description);
 
-                Ok::<Value, JsonRpcError>(response)
-            } else {
-                let response = json!(String::new());
-
-                Ok::<Value, JsonRpcError>(response)
-            }
+            Ok::<Value, JsonRpcError>(response)
         })
     })?;
 
@@ -192,17 +165,11 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
 
             let db = KV_STORE.read().await;
 
-            if let Some(indexes) = &db.indexes {
-                let follows = indexes.get_follows(&pub_key.0)?;
-                let response = json!(follows);
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let follows = indexes.get_follows(&pub_key.0)?;
+            let response = json!(follows);
 
-                Ok::<Value, JsonRpcError>(response)
-            } else {
-                let empty_vec: Vec<String> = Vec::new();
-                let response = json!(empty_vec);
-
-                Ok::<Value, JsonRpcError>(response)
-            }
+            Ok::<Value, JsonRpcError>(response)
         })
     })?;
 
@@ -215,17 +182,28 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
 
             let db = KV_STORE.read().await;
 
-            if let Some(indexes) = &db.indexes {
-                let followers = indexes.get_followers(&pub_key.0)?;
-                let response = json!(followers);
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let followers = indexes.get_followers(&pub_key.0)?;
+            let response = json!(followers);
 
-                Ok::<Value, JsonRpcError>(response)
-            } else {
-                let empty_vec: Vec<String> = Vec::new();
-                let response = json!(empty_vec);
+            Ok::<Value, JsonRpcError>(response)
+        })
+    })?;
 
-                Ok::<Value, JsonRpcError>(response)
-            }
+    // Retrieve the follow state of two peers (ie. does peer A follow peer B?).
+    //
+    // Returns a boolean.
+    rpc_module.register_method("is_following", move |params: Params, _| {
+        task::block_on(async {
+            let peers: IsFollowing = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let is_following = indexes.is_following(&peers.peer_a, &peers.peer_b)?;
+            let response = json!(is_following);
+
+            Ok::<Value, JsonRpcError>(response)
         })
     })?;
 
@@ -238,17 +216,11 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
 
             let db = KV_STORE.read().await;
 
-            if let Some(indexes) = &db.indexes {
-                let subscribers = indexes.get_channel_subscribers(&pub_key.0)?;
-                let response = json!(subscribers);
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let subscribers = indexes.get_channel_subscribers(&pub_key.0)?;
+            let response = json!(subscribers);
 
-                Ok::<Value, JsonRpcError>(response)
-            } else {
-                let empty_vec: Vec<String> = Vec::new();
-                let response = json!(empty_vec);
-
-                Ok::<Value, JsonRpcError>(response)
-            }
+            Ok::<Value, JsonRpcError>(response)
         })
     })?;
 
@@ -261,17 +233,11 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
 
             let db = KV_STORE.read().await;
 
-            if let Some(indexes) = &db.indexes {
-                let subscriptions = indexes.get_channel_subscriptions(&pub_key.0)?;
-                let response = json!(subscriptions);
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let subscriptions = indexes.get_channel_subscriptions(&pub_key.0)?;
+            let response = json!(subscriptions);
 
-                Ok::<Value, JsonRpcError>(response)
-            } else {
-                let empty_vec: Vec<String> = Vec::new();
-                let response = json!(empty_vec);
-
-                Ok::<Value, JsonRpcError>(response)
-            }
+            Ok::<Value, JsonRpcError>(response)
         })
     })?;
 

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -259,6 +259,41 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the latest image reference for the given public key.
+    //
+    // Returns a string.
+    rpc_module.register_method("latest_image", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let image = indexes.get_latest_image(&pub_key.0)?;
+            let response = json!(image);
+
+            Ok::<Value, JsonRpcError>(response)
+        })
+    })?;
+
+    // Retrieve the latest self-assigned image reference for the given public
+    // key.
+    //
+    // Returns an array of strings.
+    rpc_module.register_method("latest_self_image", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let image = indexes.get_latest_self_assigned_image(&pub_key.0)?;
+            let response = json!(image);
+
+            Ok::<Value, JsonRpcError>(response)
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -311,6 +311,23 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the self-assigned names for the given public key.
+    //
+    // Returns an array of strings.
+    rpc_module.register_method("self_names", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let names = indexes.get_self_assigned_names(&pub_key.0)?;
+            let response = json!(names);
+
+            Ok::<Value, JsonRpcError>(response)
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -125,13 +125,35 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
             let db = KV_STORE.read().await;
 
             if let Some(indexes) = &db.indexes {
-                let self_descriptions = indexes.get_self_assigned_descriptions(&pub_key.0)?;
-                let response = json!(self_descriptions);
+                let descriptions = indexes.get_self_assigned_descriptions(&pub_key.0)?;
+                let response = json!(descriptions);
 
                 Ok::<Value, JsonRpcError>(response)
             } else {
                 let empty_vec: Vec<String> = Vec::new();
                 let response = json!(empty_vec);
+
+                Ok::<Value, JsonRpcError>(response)
+            }
+        })
+    })?;
+
+    // Retrieve the latest (most-recent) description for the given public key.
+    //
+    // Returns a string.
+    rpc_module.register_method("latest_description", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            if let Some(indexes) = &db.indexes {
+                let description = indexes.get_latest_description(&pub_key.0)?;
+                let response = json!(description);
+
+                Ok::<Value, JsonRpcError>(response)
+            } else {
+                let response = json!(String::new());
 
                 Ok::<Value, JsonRpcError>(response)
             }

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -345,6 +345,23 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the latest self-assigned name for the given public key.
+    //
+    // Returns a string.
+    rpc_module.register_method("latest_self_name", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let names = indexes.get_latest_self_assigned_name(&pub_key.0)?;
+            let response = json!(names);
+
+            Ok::<Value, JsonRpcError>(response)
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -92,6 +92,29 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the descriptions for the given public key.
+    //
+    // Returns an array of descriptions.
+    rpc_module.register_method("descriptions", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            if let Some(indexes) = &db.indexes {
+                let descriptions = indexes.get_descriptions(&pub_key.0)?;
+                let response = json!(descriptions);
+
+                Ok::<Value, JsonRpcError>(response)
+            } else {
+                let empty_vec: Vec<String> = Vec::new();
+                let response = json!(empty_vec);
+
+                Ok::<Value, JsonRpcError>(response)
+            }
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -225,6 +225,23 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the image references for the given public key.
+    //
+    // Returns an array of strings.
+    rpc_module.register_method("images", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let images = indexes.get_images(&pub_key.0)?;
+            let response = json!(images);
+
+            Ok::<Value, JsonRpcError>(response)
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -206,6 +206,29 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the public keys of all feeds following the given public key.
+    //
+    // Returns an array of public keys.
+    rpc_module.register_method("followers", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            if let Some(indexes) = &db.indexes {
+                let followers = indexes.get_followers(&pub_key.0)?;
+                let response = json!(followers);
+
+                Ok::<Value, JsonRpcError>(response)
+            } else {
+                let empty_vec: Vec<String> = Vec::new();
+                let response = json!(empty_vec);
+
+                Ok::<Value, JsonRpcError>(response)
+            }
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -294,6 +294,23 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the names for the given public key.
+    //
+    // Returns an array of strings.
+    rpc_module.register_method("names", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let names = indexes.get_names(&pub_key.0)?;
+            let response = json!(names);
+
+            Ok::<Value, JsonRpcError>(response)
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -115,6 +115,29 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the self-assigned descriptions for the given public key.
+    //
+    // Returns an array of descriptions.
+    rpc_module.register_method("self_descriptions", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            if let Some(indexes) = &db.indexes {
+                let self_descriptions = indexes.get_self_assigned_descriptions(&pub_key.0)?;
+                let response = json!(self_descriptions);
+
+                Ok::<Value, JsonRpcError>(response)
+            } else {
+                let empty_vec: Vec<String> = Vec::new();
+                let response = json!(empty_vec);
+
+                Ok::<Value, JsonRpcError>(response)
+            }
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -328,6 +328,23 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the latest name for the given public key.
+    //
+    // Returns a string.
+    rpc_module.register_method("latest_name", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
+            let names = indexes.get_latest_name(&pub_key.0)?;
+            let response = json!(names);
+
+            Ok::<Value, JsonRpcError>(response)
+        })
+    })?;
+
     // Retrieve the public keys of all feeds subscribed to the given channel.
     //
     // Returns an array of public keys.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -92,6 +92,29 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
         })
     })?;
 
+    // Retrieve the public keys of all feeds subscribed to the given channel.
+    //
+    // Returns an array of public keys.
+    rpc_module.register_method("subscribers", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            if let Some(indexes) = &db.indexes {
+                let subscribers = indexes.get_channel_subscribers(&pub_key.0)?;
+                let response = json!(subscribers);
+
+                Ok::<Value, JsonRpcError>(response)
+            } else {
+                let empty_vec: Vec<String> = Vec::new();
+                let response = json!(empty_vec);
+
+                Ok::<Value, JsonRpcError>(response)
+            }
+        })
+    })?;
+
     // Retrieve a feed by public key.
     // Returns an array of messages as a KVTs.
     rpc_module.register_method("feed", move |params: Params, _| {

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -56,9 +56,31 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
             let db = KV_STORE.read().await;
 
             if let Some(indexes) = &db.indexes {
-                // Retrieve the message value for the requested message.
                 let blocks = indexes.get_blocks(&pub_key.0)?;
                 let response = json!(blocks);
+
+                Ok::<Value, JsonRpcError>(response)
+            } else {
+                let empty_vec: Vec<String> = Vec::new();
+                let response = json!(empty_vec);
+
+                Ok::<Value, JsonRpcError>(response)
+            }
+        })
+    })?;
+
+    // Retrieve the public keys of all feeds blocking the given public key.
+    //
+    // Returns an array of public keys.
+    rpc_module.register_method("blockers", move |params: Params, _| {
+        task::block_on(async {
+            let pub_key: PubKey = params.parse()?;
+
+            let db = KV_STORE.read().await;
+
+            if let Some(indexes) = &db.indexes {
+                let blockers = indexes.get_blockers(&pub_key.0)?;
+                let response = json!(blockers);
 
                 Ok::<Value, JsonRpcError>(response)
             } else {

--- a/solar/src/actors/muxrpc/history_stream.rs
+++ b/solar/src/actors/muxrpc/history_stream.rs
@@ -147,11 +147,11 @@ where
                 // Instantiate the history stream request args for the given peer.
                 // The `live` arg means: keep the connection open after initial
                 // replication.
-                let mut args = dto::CreateHistoryStreamIn::new(peer_pk.to_owned()).live(true);
+                let mut args = dto::CreateHistoryStreamIn::new(format!("@{}", peer_pk)).live(true);
 
                 // Retrieve the sequence number of the most recent message for
                 // this peer from the local key-value store.
-                if let Some(last_seq) = KV_STORE.read().await.get_latest_seq(&peer_pk.to_owned())? {
+                if let Some(last_seq) = KV_STORE.read().await.get_latest_seq(peer_pk)? {
                     // Use the latest sequence number to update the request args.
                     args = args.after_seq(last_seq);
                 }
@@ -161,12 +161,11 @@ where
 
                 // Insert the history stream request ID and peer ID
                 // (public key) into the peers hash map.
-                self.peers.insert(id, peer_pk.to_owned());
+                self.peers.insert(id, peer_pk.to_string());
 
                 info!(
                     "requesting messages authored by peer {} after {:?}",
-                    peer_pk.to_owned(),
-                    args.seq
+                    peer_pk, args.seq
                 );
             }
 

--- a/solar/src/error.rs
+++ b/solar/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     DeserializeToml(de::Error),
     /// Failed to send message on futures channel.
     FuturesChannel(mpsc::SendError),
+    /// Database indexes.
+    Indexes,
     /// Validation error; invalid message sequence number.
     InvalidSequence,
     /// io::Error.
@@ -67,6 +69,7 @@ impl fmt::Display for Error {
             Error::FuturesChannel(err) => {
                 write!(f, "Failed to send message on futures channel: {err}")
             }
+            Error::Indexes => write!(f, "Indexes error: indexes not initialised"),
             // TODO: Attach context so we know the identity of the offending message.
             Error::InvalidSequence => write!(
                 f,
@@ -206,6 +209,7 @@ impl From<Error> for JsonRpcErrorOwned {
             Error::Validation(err_msg) => {
                 JsonRpcErrorOwned::owned(-32002, SERVER_ERROR_MSG, Some(err_msg.to_string()))
             }
+            Error::Indexes => JsonRpcErrorOwned::owned(-32003, SERVER_ERROR_MSG, None::<String>),
             _ => todo!(),
         }
     }

--- a/solar/src/storage/indexes.rs
+++ b/solar/src/storage/indexes.rs
@@ -7,6 +7,7 @@ use kuska_ssb::{
     api::dto::content::{Image, TypedMessage as MessageContent},
     feed::Message as MessageValue,
 };
+use log::{debug, info};
 use sled::{Db, Tree};
 
 use crate::Result;
@@ -38,6 +39,7 @@ pub struct Indexes {
 impl Indexes {
     /// Open a database tree for each index.
     pub fn open(db: &Db) -> Result<Indexes> {
+        info!("Opening database index trees");
         let blocks = db.open_tree("blocks")?;
         let blockers = db.open_tree("blockers")?;
         let channel_subscribers = db.open_tree("channel_subscribers")?;
@@ -67,6 +69,7 @@ impl Indexes {
 
     /// Index a message based on the author (SSB ID) and content type.
     pub fn index_msg(&self, author_id: &str, msg_val: MessageValue) -> Result<()> {
+        debug!("Indexing message {} from {}", msg_val.sequence(), author_id);
         if let Some(content_val) = msg_val.value.get("content") {
             let content: MessageContent = serde_json::from_value(content_val.to_owned())?;
 

--- a/solar/src/storage/kv.rs
+++ b/solar/src/storage/kv.rs
@@ -1,6 +1,6 @@
 use futures::SinkExt;
 use kuska_ssb::feed::{Feed as MessageKvt, Message as MessageValue};
-use log::warn;
+use log::{debug, warn};
 use serde::{Deserialize, Serialize};
 use sled::{Config as DbConfig, Db};
 
@@ -246,6 +246,7 @@ impl KvStorage {
 
     /// Append a message value to a feed.
     pub async fn append_feed(&self, msg_val: MessageValue) -> Result<u64> {
+        debug!("Appending message to feed in database");
         let seq_num = self.get_latest_seq(msg_val.author())?.map_or(0, |num| num) + 1;
 
         // TODO: We should really be performing more comprehensive validation.
@@ -275,6 +276,7 @@ impl KvStorage {
         // list of peers.
         self.set_peer(&author, seq_num).await?;
 
+        debug!("Passing message to indexer");
         // Pass the author and message value to the indexer.
         if let Some(indexes) = &self.indexes {
             indexes.index_msg(&author, msg_val)?


### PR DESCRIPTION
This PR exposes all of the previously added database index methods (https://github.com/mycognosist/solar/pull/78) as JSON-RPC methods. README documentation has been updated.

I've also fixed a replication bug that snuck in when some of the configuration changes were being made. Namely, Patchwork will not replicate with `solar` if the requested public key in the create history streams arguments is not preceded by an `@`. Replication is now working in both directions. 