### PR TITLE
Replace generic broker message type with enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,7 +1089,7 @@ dependencies = [
 [[package]]
 name = "kuska-ssb"
 version = "0.4.2"
-source = "git+https://github.com/Kuska-ssb/ssb?branch=master#578d0187d9e28716f526d8138f8a3b4c1d9fa728"
+source = "git+https://github.com/Kuska-ssb/ssb?branch=master#7e1c633136380e8d83e6d239ed3c67f53f68abe9"
 dependencies = [
  "async-std",
  "async-stream",

--- a/solar/src/actors/muxrpc/blobs_get.rs
+++ b/solar/src/actors/muxrpc/blobs_get.rs
@@ -15,7 +15,7 @@ use log::{info, trace, warn};
 
 use crate::{
     actors::muxrpc::handler::{RpcHandler, RpcInput},
-    broker::ChBrokerSend,
+    broker::{BrokerMessage, ChBrokerSend},
     node::BLOB_STORE,
     storage::blob::ToBlobHashId,
     Result,
@@ -77,12 +77,8 @@ where
             RpcInput::Network(req_no, rpc::RecvMsg::RpcResponse(_type, res)) => {
                 return self.recv_rpc_response(api, *req_no, res).await;
             }
-            RpcInput::Message(msg) => {
-                if let Some(get_event) = msg.downcast_ref::<RpcBlobsGetEvent>() {
-                    match get_event {
-                        RpcBlobsGetEvent::Get(req) => return self.event_get(api, &req).await,
-                    }
-                }
+            RpcInput::Message(BrokerMessage::RpcBlobsGet(RpcBlobsGetEvent::Get(req))) => {
+                return self.event_get(api, &req).await;
             }
             _ => {}
         }

--- a/solar/src/actors/muxrpc/blobs_get.rs
+++ b/solar/src/actors/muxrpc/blobs_get.rs
@@ -78,7 +78,7 @@ where
                 return self.recv_rpc_response(api, *req_no, res).await;
             }
             RpcInput::Message(BrokerMessage::RpcBlobsGet(RpcBlobsGetEvent::Get(req))) => {
-                return self.event_get(api, &req).await;
+                return self.event_get(api, req).await;
             }
             _ => {}
         }

--- a/solar/src/actors/muxrpc/blobs_get.rs
+++ b/solar/src/actors/muxrpc/blobs_get.rs
@@ -21,6 +21,8 @@ use crate::{
     Result,
 };
 
+#[derive(Clone)]
+// TODO: Make this a tuple struct.
 pub enum RpcBlobsGetEvent {
     Get(dto::BlobsGetIn),
 }
@@ -69,7 +71,7 @@ where
                     _ => {}
                 }
             }
-            RpcInput::Network(req_no, rpc::RecvMsg::CancelStreamRespose()) => {
+            RpcInput::Network(req_no, rpc::RecvMsg::CancelStreamResponse()) => {
                 return self.recv_cancelstream(api, *req_no).await;
             }
             RpcInput::Network(req_no, rpc::RecvMsg::RpcResponse(_type, res)) => {
@@ -78,7 +80,7 @@ where
             RpcInput::Message(msg) => {
                 if let Some(get_event) = msg.downcast_ref::<RpcBlobsGetEvent>() {
                     match get_event {
-                        RpcBlobsGetEvent::Get(req) => return self.event_get(api, req).await,
+                        RpcBlobsGetEvent::Get(req) => return self.event_get(api, &req).await,
                     }
                 }
             }

--- a/solar/src/actors/muxrpc/blobs_get.rs
+++ b/solar/src/actors/muxrpc/blobs_get.rs
@@ -21,7 +21,7 @@ use crate::{
     Result,
 };
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 // TODO: Make this a tuple struct.
 pub enum RpcBlobsGetEvent {
     Get(dto::BlobsGetIn),

--- a/solar/src/actors/muxrpc/blobs_get.rs
+++ b/solar/src/actors/muxrpc/blobs_get.rs
@@ -22,10 +22,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-// TODO: Make this a tuple struct.
-pub enum RpcBlobsGetEvent {
-    Get(dto::BlobsGetIn),
-}
+pub struct RpcBlobsGetEvent(pub dto::BlobsGetIn);
 
 pub struct BlobsGetHandler<W>
 where
@@ -77,7 +74,7 @@ where
             RpcInput::Network(req_no, rpc::RecvMsg::RpcResponse(_type, res)) => {
                 return self.recv_rpc_response(api, *req_no, res).await;
             }
-            RpcInput::Message(BrokerMessage::RpcBlobsGet(RpcBlobsGetEvent::Get(req))) => {
+            RpcInput::Message(BrokerMessage::RpcBlobsGet(RpcBlobsGetEvent(req))) => {
                 return self.event_get(api, req).await;
             }
             _ => {}

--- a/solar/src/actors/muxrpc/blobs_wants.rs
+++ b/solar/src/actors/muxrpc/blobs_wants.rs
@@ -20,9 +20,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-pub enum RpcBlobsWantsEvent {
-    BroadcastWants(Vec<(String, i64)>),
-}
+pub struct RpcBlobsWantsEvent(Vec<(String, i64)>);
 
 #[derive(PartialEq)]
 enum Wants {
@@ -154,9 +152,9 @@ where
                 }
             }
             RpcInput::Message(msg) => {
-                if let BrokerMessage::RpcBlobsWants(RpcBlobsWantsEvent::BroadcastWants(ids)) = msg {
+                if let BrokerMessage::RpcBlobsWants(RpcBlobsWantsEvent(ids)) = msg {
                     return self.event_wants_broadcast(api, ids).await;
-                } else if let BrokerMessage::StoreBlob(StoreBlobEvent::Added(blob_id)) = msg {
+                } else if let BrokerMessage::StoreBlob(StoreBlobEvent(blob_id)) = msg {
                     return self.event_stoblob_added(api, blob_id).await;
                 }
             }
@@ -282,7 +280,7 @@ where
         // broadcast other peers with the blobs I don't have
         let broker_msg = BrokerEvent::new(
             Destination::Broadcast,
-            BrokerMessage::RpcBlobsWants(RpcBlobsWantsEvent::BroadcastWants(broadcast)),
+            BrokerMessage::RpcBlobsWants(RpcBlobsWantsEvent(broadcast)),
         );
         ch_broker.send(broker_msg).await.unwrap();
 

--- a/solar/src/actors/muxrpc/blobs_wants.rs
+++ b/solar/src/actors/muxrpc/blobs_wants.rs
@@ -19,7 +19,7 @@ use crate::{
     Result,
 };
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum RpcBlobsWantsEvent {
     BroadcastWants(Vec<(String, i64)>),
 }

--- a/solar/src/actors/muxrpc/blobs_wants.rs
+++ b/solar/src/actors/muxrpc/blobs_wants.rs
@@ -155,9 +155,9 @@ where
             }
             RpcInput::Message(msg) => {
                 if let BrokerMessage::RpcBlobsWants(RpcBlobsWantsEvent::BroadcastWants(ids)) = msg {
-                    return self.event_wants_broadcast(api, &ids).await;
+                    return self.event_wants_broadcast(api, ids).await;
                 } else if let BrokerMessage::StoreBlob(StoreBlobEvent::Added(blob_id)) = msg {
-                    return self.event_stoblob_added(api, &blob_id).await;
+                    return self.event_stoblob_added(api, blob_id).await;
                 }
             }
             RpcInput::Timer => {

--- a/solar/src/actors/muxrpc/blobs_wants.rs
+++ b/solar/src/actors/muxrpc/blobs_wants.rs
@@ -15,7 +15,7 @@ use crate::{
     actors::muxrpc::handler::{RpcHandler, RpcInput},
     broker::{BrokerEvent, BrokerMessage, ChBrokerSend, Destination},
     node::BLOB_STORE,
-    storage::blob::{StoBlobEvent, ToBlobHashId},
+    storage::blob::{StoreBlobEvent, ToBlobHashId},
     Result,
 };
 
@@ -156,7 +156,7 @@ where
             RpcInput::Message(msg) => {
                 if let BrokerMessage::RpcBlobsWants(RpcBlobsWantsEvent::BroadcastWants(ids)) = msg {
                     return self.event_wants_broadcast(api, &ids).await;
-                } else if let BrokerMessage::StoBlob(StoBlobEvent::Added(blob_id)) = msg {
+                } else if let BrokerMessage::StoreBlob(StoreBlobEvent::Added(blob_id)) = msg {
                     return self.event_stoblob_added(api, &blob_id).await;
                 }
             }

--- a/solar/src/actors/muxrpc/blobs_wants.rs
+++ b/solar/src/actors/muxrpc/blobs_wants.rs
@@ -154,18 +154,10 @@ where
                 }
             }
             RpcInput::Message(msg) => {
-                if let Some(wants_event) = msg.downcast_ref::<RpcBlobsWantsEvent>() {
-                    match wants_event {
-                        RpcBlobsWantsEvent::BroadcastWants(ids) => {
-                            return self.event_wants_broadcast(api, &ids).await
-                        }
-                    }
-                } else if let Some(stoblob_event) = msg.downcast_ref::<StoBlobEvent>() {
-                    match stoblob_event {
-                        StoBlobEvent::Added(blob_id) => {
-                            return self.event_stoblob_added(api, &blob_id).await
-                        }
-                    }
+                if let BrokerMessage::RpcBlobsWants(RpcBlobsWantsEvent::BroadcastWants(ids)) = msg {
+                    return self.event_wants_broadcast(api, &ids).await;
+                } else if let BrokerMessage::StoBlob(StoBlobEvent::Added(blob_id)) = msg {
+                    return self.event_stoblob_added(api, &blob_id).await;
                 }
             }
             RpcInput::Timer => {

--- a/solar/src/actors/muxrpc/history_stream.rs
+++ b/solar/src/actors/muxrpc/history_stream.rs
@@ -87,7 +87,7 @@ where
                 self.recv_error_response(api, *req_no, err).await
             }
             // Handle a broker message.
-            RpcInput::Message(BrokerMessage::StoreKv(StoreKvEvent::IdChanged(id))) => {
+            RpcInput::Message(BrokerMessage::StoreKv(StoreKvEvent(id))) => {
                 // Notification from the key-value store indicating that
                 // a new message has just been appended to the feed
                 // identified by `id`.

--- a/solar/src/actors/muxrpc/history_stream.rs
+++ b/solar/src/actors/muxrpc/history_stream.rs
@@ -88,7 +88,7 @@ where
                 // Notification from the key-value store indicating that
                 // a new message has just been appended to the feed
                 // identified by `id`.
-                return self.recv_storageevent_idchanged(api, &id).await;
+                return self.recv_storageevent_idchanged(api, id).await;
             }
             // Handle a timer event.
             RpcInput::Timer => self.on_timer(api).await,

--- a/solar/src/actors/muxrpc/history_stream.rs
+++ b/solar/src/actors/muxrpc/history_stream.rs
@@ -13,7 +13,10 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 
 use crate::{
-    actors::muxrpc::handler::{RpcHandler, RpcInput},
+    actors::muxrpc::{
+        blobs_get::RpcBlobsGetEvent,
+        handler::{RpcHandler, RpcInput},
+    },
     broker::{BrokerEvent, BrokerMessage, ChBrokerSend, Destination},
     config::{PEERS_TO_REPLICATE, RESYNC_CONFIG, SECRET_CONFIG},
     node::BLOB_STORE,
@@ -232,7 +235,7 @@ where
                 // blobstore.
                 for key in self.extract_blob_refs(&msg) {
                     if !BLOB_STORE.read().await.exists(&key) {
-                        let event = super::blobs_get::RpcBlobsGetEvent::Get(dto::BlobsGetIn {
+                        let event = RpcBlobsGetEvent(dto::BlobsGetIn {
                             key,
                             size: None,
                             max: None,

--- a/solar/src/actors/muxrpc/history_stream.rs
+++ b/solar/src/actors/muxrpc/history_stream.rs
@@ -18,7 +18,7 @@ use crate::{
     config::{PEERS_TO_REPLICATE, RESYNC_CONFIG, SECRET_CONFIG},
     node::BLOB_STORE,
     node::KV_STORE,
-    storage::kv::StoKvEvent,
+    storage::kv::StoreKvEvent,
     Result,
 };
 
@@ -84,7 +84,7 @@ where
                 self.recv_error_response(api, *req_no, err).await
             }
             // Handle a broker message.
-            RpcInput::Message(BrokerMessage::StoKv(StoKvEvent::IdChanged(id))) => {
+            RpcInput::Message(BrokerMessage::StoreKv(StoreKvEvent::IdChanged(id))) => {
                 // Notification from the key-value store indicating that
                 // a new message has just been appended to the feed
                 // identified by `id`.

--- a/solar/src/actors/muxrpc/history_stream.rs
+++ b/solar/src/actors/muxrpc/history_stream.rs
@@ -84,18 +84,11 @@ where
                 self.recv_error_response(api, *req_no, err).await
             }
             // Handle a broker message.
-            RpcInput::Message(msg) => {
-                if let Some(kv_event) = msg.downcast_ref::<StoKvEvent>() {
-                    match kv_event {
-                        // Notification from the key-value store indicating that
-                        // a new message has just been appended to the feed
-                        // identified by `id`.
-                        StoKvEvent::IdChanged(id) => {
-                            return self.recv_storageevent_idchanged(api, &id).await
-                        }
-                    }
-                }
-                Ok(false)
+            RpcInput::Message(BrokerMessage::StoKv(StoKvEvent::IdChanged(id))) => {
+                // Notification from the key-value store indicating that
+                // a new message has just been appended to the feed
+                // identified by `id`.
+                return self.recv_storageevent_idchanged(api, &id).await;
             }
             // Handle a timer event.
             RpcInput::Timer => self.on_timer(api).await,

--- a/solar/src/actors/muxrpc/mod.rs
+++ b/solar/src/actors/muxrpc/mod.rs
@@ -5,8 +5,8 @@ mod handler;
 mod history_stream;
 mod whoami;
 
-pub use blobs_get::BlobsGetHandler;
-pub use blobs_wants::BlobsWantsHandler;
+pub use blobs_get::{BlobsGetHandler, RpcBlobsGetEvent};
+pub use blobs_wants::{BlobsWantsHandler, RpcBlobsWantsEvent};
 pub use get::GetHandler;
 pub use handler::{RpcHandler, RpcInput};
 pub use history_stream::HistoryStreamHandler;

--- a/solar/src/actors/network/connection.rs
+++ b/solar/src/actors/network/connection.rs
@@ -11,6 +11,7 @@ use log::info;
 
 use crate::{
     actors::network::connection_manager::{ConnectionEvent, CONNECTION_MANAGER},
+    // TODO: Replace this with explicit imports.
     broker::*,
     config::{NETWORK_KEY, PEERS_TO_REPLICATE},
     Result,
@@ -112,7 +113,10 @@ pub async fn actor(
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Error(connection_data, err.to_string()),
+                    BrokerMessage::Connection(ConnectionEvent::Error(
+                        connection_data,
+                        err.to_string(),
+                    )),
                 ))
                 .await?;
         }
@@ -121,7 +125,9 @@ pub async fn actor(
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Disconnected(connection_data.to_owned()),
+                    BrokerMessage::Connection(ConnectionEvent::Disconnected(
+                        connection_data.to_owned(),
+                    )),
                 ))
                 .await?;
         }
@@ -160,7 +166,9 @@ pub async fn actor_inner(
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Connecting(connection_data.to_owned()),
+                    BrokerMessage::Connection(ConnectionEvent::Connecting(
+                        connection_data.to_owned(),
+                    )),
                 ))
                 .await?;
 
@@ -171,7 +179,9 @@ pub async fn actor_inner(
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Handshaking(connection_data.to_owned()),
+                    BrokerMessage::Connection(ConnectionEvent::Handshaking(
+                        connection_data.to_owned(),
+                    )),
                 ))
                 .await?;
 
@@ -185,7 +195,9 @@ pub async fn actor_inner(
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Connected(connection_data.to_owned()),
+                    BrokerMessage::Connection(ConnectionEvent::Connected(
+                        connection_data.to_owned(),
+                    )),
                 ))
                 .await?;
 
@@ -205,7 +217,9 @@ pub async fn actor_inner(
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Connecting(connection_data.to_owned()),
+                    BrokerMessage::Connection(ConnectionEvent::Connecting(
+                        connection_data.to_owned(),
+                    )),
                 ))
                 .await?;
 
@@ -213,7 +227,9 @@ pub async fn actor_inner(
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Handshaking(connection_data.to_owned()),
+                    BrokerMessage::Connection(ConnectionEvent::Handshaking(
+                        connection_data.to_owned(),
+                    )),
                 ))
                 .await?;
 
@@ -238,7 +254,9 @@ pub async fn actor_inner(
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Connected(connection_data.to_owned()),
+                    BrokerMessage::Connection(ConnectionEvent::Connected(
+                        connection_data.to_owned(),
+                    )),
                 ))
                 .await?;
 
@@ -259,7 +277,9 @@ pub async fn actor_inner(
                 ch_broker
                     .send(BrokerEvent::new(
                         Destination::Broadcast,
-                        ConnectionEvent::Disconnecting(connection_data.to_owned()),
+                        BrokerMessage::Connection(ConnectionEvent::Disconnecting(
+                            connection_data.to_owned(),
+                        )),
                     ))
                     .await?;
 
@@ -286,7 +306,9 @@ pub async fn actor_inner(
                 ch_broker
                     .send(BrokerEvent::new(
                         Destination::Broadcast,
-                        ConnectionEvent::Disconnecting(connection_data.to_owned()),
+                        BrokerMessage::Connection(ConnectionEvent::Disconnecting(
+                            connection_data.to_owned(),
+                        )),
                     ))
                     .await?;
 

--- a/solar/src/actors/network/connection.rs
+++ b/solar/src/actors/network/connection.rs
@@ -11,8 +11,7 @@ use log::info;
 
 use crate::{
     actors::network::connection_manager::{ConnectionEvent, CONNECTION_MANAGER},
-    // TODO: Replace this with explicit imports.
-    broker::*,
+    broker::{ActorEndpoint, Broker, BrokerEvent, BrokerMessage, Destination, BROKER},
     config::{NETWORK_KEY, PEERS_TO_REPLICATE},
     Result,
 };

--- a/solar/src/actors/network/connection_manager.rs
+++ b/solar/src/actors/network/connection_manager.rs
@@ -20,7 +20,7 @@ pub static CONNECTION_MANAGER: Lazy<Arc<RwLock<ConnectionManager>>> =
     Lazy::new(|| Arc::new(RwLock::new(ConnectionManager::new())));
 
 /// Connection events with associated connection data.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ConnectionEvent {
     Connecting(ConnectionData),
     Handshaking(ConnectionData),

--- a/solar/src/actors/network/connection_manager.rs
+++ b/solar/src/actors/network/connection_manager.rs
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;
 
 use crate::{
     actors::network::connection::ConnectionData,
-    broker::{ActorEndpoint, BROKER},
+    broker::{ActorEndpoint, BrokerMessage, BROKER},
 };
 
 /// The connection manager for the solar node.
@@ -135,55 +135,53 @@ impl ConnectionManager {
                     break;
                 },
                 msg = broker_msg_ch.next().fuse() => {
-                    if let Some(msg) = msg {
-                        if let Some(conn_event) = msg.downcast_ref::<ConnectionEvent>() {
-                            match conn_event {
-                                ConnectionEvent::Connecting(data) => {
-                                    trace!(target: "connection-manager", "Connecting: {data}");
-                                }
-                                ConnectionEvent::Handshaking(data) => {
-                                    trace!(target: "connection-manager", "Handshaking: {data}");
-                                }
-                                ConnectionEvent::Connected(data) => {
-                                    trace!(target: "connection-manager", "Connected: {data}");
+                    if let Some(BrokerMessage::Connection(conn_event)) = msg {
+                        match conn_event {
+                            ConnectionEvent::Connecting(data) => {
+                                trace!(target: "connection-manager", "Connecting: {data}");
+                            }
+                            ConnectionEvent::Handshaking(data) => {
+                                trace!(target: "connection-manager", "Handshaking: {data}");
+                            }
+                            ConnectionEvent::Connected(data) => {
+                                trace!(target: "connection-manager", "Connected: {data}");
 
-                                    // Add the peer to the list of connected peers.
-                                    if let Some(public_key) = data.peer_public_key {
-                                        CONNECTION_MANAGER
-                                            .write()
-                                            .await
-                                            .insert_connected_peer(public_key);
-                                    }
-                                }
-                                ConnectionEvent::Replicating(data) => {
-                                    trace!(target: "connection-manager", "Replicating: {data}");
-                                }
-                                ConnectionEvent::Disconnecting(data) => {
-                                    trace!(target: "connection-manager", "Disconnecting: {data}");
-                                }
-                                ConnectionEvent::Disconnected(data) => {
-                                    trace!(target: "connection-manager", "Disconnected: {data}");
-
-                                    // Remove the peer from the list of connected peers.
-                                    if let Some(public_key) = data.peer_public_key {
+                                // Add the peer to the list of connected peers.
+                                if let Some(public_key) = data.peer_public_key {
                                     CONNECTION_MANAGER
                                         .write()
                                         .await
-                                        .remove_connected_peer(public_key);
-
-                                    }
+                                        .insert_connected_peer(public_key);
                                 }
-                                ConnectionEvent::Error(data, err) => {
-                                    trace!(target: "connection-manager", "Error: {data}: {err}");
+                            }
+                            ConnectionEvent::Replicating(data) => {
+                                trace!(target: "connection-manager", "Replicating: {data}");
+                            }
+                            ConnectionEvent::Disconnecting(data) => {
+                                trace!(target: "connection-manager", "Disconnecting: {data}");
+                            }
+                            ConnectionEvent::Disconnected(data) => {
+                                trace!(target: "connection-manager", "Disconnected: {data}");
 
-                                    // Remove the peer from the list of connected peers.
-                                    if let Some(public_key) = data.peer_public_key {
-                                    CONNECTION_MANAGER
-                                        .write()
-                                        .await
-                                        .remove_connected_peer(public_key);
+                                // Remove the peer from the list of connected peers.
+                                if let Some(public_key) = data.peer_public_key {
+                                CONNECTION_MANAGER
+                                    .write()
+                                    .await
+                                    .remove_connected_peer(public_key);
 
-                                    }
+                                }
+                            }
+                            ConnectionEvent::Error(data, err) => {
+                                trace!(target: "connection-manager", "Error: {data}: {err}");
+
+                                // Remove the peer from the list of connected peers.
+                                if let Some(public_key) = data.peer_public_key {
+                                CONNECTION_MANAGER
+                                    .write()
+                                    .await
+                                    .remove_connected_peer(public_key);
+
                                 }
                             }
                         }

--- a/solar/src/actors/network/connection_scheduler.rs
+++ b/solar/src/actors/network/connection_scheduler.rs
@@ -25,11 +25,12 @@ use log::debug;
 
 use crate::{
     actors::network::connection_manager::{ConnectionEvent, CONNECTION_MANAGER},
-    broker::{ActorEndpoint, BrokerEvent, Destination, BROKER},
+    broker::{ActorEndpoint, BrokerEvent, BrokerMessage, Destination, BROKER},
     Result,
 };
 
 /// A request to dial the peer identified by the given public key and address.
+#[derive(Clone)]
 pub struct DialRequest(pub (PublicKey, String));
 
 // Custom `Display` implementation so we can easily log dial requests.
@@ -179,7 +180,7 @@ pub async fn actor(peers: Vec<(PublicKey, String)>) -> Result<()> {
                             // Otherwise, send a dial request to the dialer.
                             let dial_request = DialRequest((public_key, addr));
                             debug!("{}", dial_request);
-                            ch_broker.send(BrokerEvent::new(Destination::Broadcast, dial_request)).await?
+                            ch_broker.send(BrokerEvent::new(Destination::Broadcast, BrokerMessage::Dial(dial_request))).await?
                         }
                     }
                 }
@@ -197,7 +198,7 @@ pub async fn actor(peers: Vec<(PublicKey, String)>) -> Result<()> {
                             // Otherwise, send a dial request to the dialer.
                             let dial_request = DialRequest((public_key, addr));
                             debug!("{}", dial_request);
-                            ch_broker.send(BrokerEvent::new(Destination::Broadcast, dial_request)).await?
+                            ch_broker.send(BrokerEvent::new(Destination::Broadcast, BrokerMessage::Dial(dial_request))).await?
                         }
                     }
                 }

--- a/solar/src/actors/network/connection_scheduler.rs
+++ b/solar/src/actors/network/connection_scheduler.rs
@@ -30,7 +30,7 @@ use crate::{
 };
 
 /// A request to dial the peer identified by the given public key and address.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct DialRequest(pub (PublicKey, String));
 
 // Custom `Display` implementation so we can easily log dial requests.

--- a/solar/src/actors/network/dialer.rs
+++ b/solar/src/actors/network/dialer.rs
@@ -50,7 +50,7 @@ pub async fn actor(selective_replication: bool) -> Result<()> {
                             SECRET_CONFIG.get().unwrap().to_owned_identity()?,
                             TcpConnection::Dial {
                                 addr: addr.to_string(),
-                                public_key: *public_key,
+                                public_key,
                             },
                             selective_replication,
                         ));

--- a/solar/src/actors/replication/classic.rs
+++ b/solar/src/actors/replication/classic.rs
@@ -24,8 +24,9 @@ use crate::{
             connection_manager::{ConnectionEvent, CONNECTION_MANAGER},
         },
     },
-    // TODO: Use explicit imports.
-    broker::*,
+    broker::{
+        ActorEndpoint, BrokerEvent, BrokerMessage, ChMsgRecv, ChSigRecv, Destination, BROKER,
+    },
     Result,
 };
 

--- a/solar/src/actors/replication/classic.rs
+++ b/solar/src/actors/replication/classic.rs
@@ -24,6 +24,7 @@ use crate::{
             connection_manager::{ConnectionEvent, CONNECTION_MANAGER},
         },
     },
+    // TODO: Use explicit imports.
     broker::*,
     Result,
 };
@@ -54,7 +55,9 @@ pub async fn actor<R: Read + Unpin + Send + Sync, W: Write + Unpin + Send + Sync
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Disconnecting(connection_data.to_owned()),
+                    BrokerMessage::Connection(ConnectionEvent::Disconnecting(
+                        connection_data.to_owned(),
+                    )),
                 ))
                 .await?;
         }
@@ -69,7 +72,10 @@ pub async fn actor<R: Read + Unpin + Send + Sync, W: Write + Unpin + Send + Sync
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Error(connection_data, err.to_string()),
+                    BrokerMessage::Connection(ConnectionEvent::Error(
+                        connection_data,
+                        err.to_string(),
+                    )),
                 ))
                 .await?;
         }
@@ -103,7 +109,7 @@ pub async fn actor_inner<R: Read + Unpin + Send + Sync, W: Write + Unpin + Send 
     ch_broker
         .send(BrokerEvent::new(
             Destination::Broadcast,
-            ConnectionEvent::Replicating(connection_data.to_owned()),
+            BrokerMessage::Connection(ConnectionEvent::Replicating(connection_data.to_owned())),
         ))
         .await?;
 

--- a/solar/src/broker.rs
+++ b/solar/src/broker.rs
@@ -1,12 +1,6 @@
 use std::collections::hash_map::HashMap;
 
-use async_std::{
-    prelude::*,
-    sync::{Arc, Mutex},
-    task,
-    task::JoinHandle,
-};
-use core::any::Any;
+use async_std::{prelude::*, sync::Mutex, task, task::JoinHandle};
 use futures::{
     channel::{mpsc, oneshot},
     select_biased, FutureExt, SinkExt,

--- a/solar/src/broker.rs
+++ b/solar/src/broker.rs
@@ -13,7 +13,7 @@ use crate::{
         muxrpc::{RpcBlobsGetEvent, RpcBlobsWantsEvent},
         network::{connection_manager::ConnectionEvent, connection_scheduler::DialRequest},
     },
-    storage::{blob::StoBlobEvent, kv::StoKvEvent},
+    storage::{blob::StoreBlobEvent, kv::StoreKvEvent},
     Result,
 };
 
@@ -26,10 +26,8 @@ pub enum BrokerMessage {
     Dial(DialRequest),
     RpcBlobsGet(RpcBlobsGetEvent),
     RpcBlobsWants(RpcBlobsWantsEvent),
-    // TODO: Rename these to `StoreBlob` and `StoreBlobEvent`.
-    StoBlob(StoBlobEvent),
-    // TODO: Rename these to `StoreKv` and `StoreKvEvent`.
-    StoKv(StoKvEvent),
+    StoreBlob(StoreBlobEvent),
+    StoreKv(StoreKvEvent),
 }
 
 pub type ChBrokerSend = mpsc::UnboundedSender<BrokerEvent>;

--- a/solar/src/broker.rs
+++ b/solar/src/broker.rs
@@ -20,7 +20,7 @@ use crate::{
 #[derive(Debug)]
 pub struct Void {}
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum BrokerMessage {
     Connection(ConnectionEvent),
     Dial(DialRequest),

--- a/solar/src/storage/blob.rs
+++ b/solar/src/storage/blob.rs
@@ -9,11 +9,9 @@ use sha2::{Digest, Sha256};
 
 use crate::broker::{BrokerEvent, BrokerMessage, ChBrokerSend, Destination};
 
+/// A blob has been added to the store.
 #[derive(Debug, Clone)]
-// TODO: Make this a tuple struct.
-pub enum StoreBlobEvent {
-    Added(String),
-}
+pub struct StoreBlobEvent(pub String);
 
 #[derive(Default)]
 pub struct BlobStorage {
@@ -60,7 +58,7 @@ impl BlobStorage {
 
         let broker_msg = BrokerEvent::new(
             Destination::Broadcast,
-            BrokerMessage::StoreBlob(StoreBlobEvent::Added(id.clone())),
+            BrokerMessage::StoreBlob(StoreBlobEvent(id.clone())),
         );
 
         self.ch_broker

--- a/solar/src/storage/blob.rs
+++ b/solar/src/storage/blob.rs
@@ -7,8 +7,10 @@ use std::{
 use futures::SinkExt;
 use sha2::{Digest, Sha256};
 
-use crate::broker::{BrokerEvent, ChBrokerSend, Destination};
+use crate::broker::{BrokerEvent, BrokerMessage, ChBrokerSend, Destination};
 
+#[derive(Clone)]
+// TODO: Make this a tuple struct.
 pub enum StoBlobEvent {
     Added(String),
 }
@@ -56,7 +58,10 @@ impl BlobStorage {
         let id = content.as_ref().blob_hash_id();
         File::create(self.path_of(&id))?.write_all(content.as_ref())?;
 
-        let broker_msg = BrokerEvent::new(Destination::Broadcast, StoBlobEvent::Added(id.clone()));
+        let broker_msg = BrokerEvent::new(
+            Destination::Broadcast,
+            BrokerMessage::StoBlob(StoBlobEvent::Added(id.clone())),
+        );
 
         self.ch_broker
             .as_ref()

--- a/solar/src/storage/blob.rs
+++ b/solar/src/storage/blob.rs
@@ -11,7 +11,7 @@ use crate::broker::{BrokerEvent, BrokerMessage, ChBrokerSend, Destination};
 
 #[derive(Debug, Clone)]
 // TODO: Make this a tuple struct.
-pub enum StoBlobEvent {
+pub enum StoreBlobEvent {
     Added(String),
 }
 
@@ -60,7 +60,7 @@ impl BlobStorage {
 
         let broker_msg = BrokerEvent::new(
             Destination::Broadcast,
-            BrokerMessage::StoBlob(StoBlobEvent::Added(id.clone())),
+            BrokerMessage::StoreBlob(StoreBlobEvent::Added(id.clone())),
         );
 
         self.ch_broker

--- a/solar/src/storage/blob.rs
+++ b/solar/src/storage/blob.rs
@@ -9,7 +9,7 @@ use sha2::{Digest, Sha256};
 
 use crate::broker::{BrokerEvent, BrokerMessage, ChBrokerSend, Destination};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 // TODO: Make this a tuple struct.
 pub enum StoBlobEvent {
     Added(String),

--- a/solar/src/storage/kv.rs
+++ b/solar/src/storage/kv.rs
@@ -23,11 +23,10 @@ const PREFIX_BLOB: u8 = 3u8;
 /// Prefix for a key to a peer.
 const PREFIX_PEER: u8 = 4u8;
 
+/// The feed belonging to the given SSB ID has changed
+/// (ie. a new message has been appended to the feed).
 #[derive(Debug, Clone)]
-// TODO: Make this a tuple struct.
-pub enum StoreKvEvent {
-    IdChanged(String),
-}
+pub struct StoreKvEvent(pub String);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlobStatus {
@@ -289,7 +288,7 @@ impl KvStorage {
         // key has been updated.
         let broker_msg = BrokerEvent::new(
             Destination::Broadcast,
-            BrokerMessage::StoreKv(StoreKvEvent::IdChanged(author)),
+            BrokerMessage::StoreKv(StoreKvEvent(author)),
         );
 
         // Matching on the error here (instead of unwrapping) allows us to

--- a/solar/src/storage/kv.rs
+++ b/solar/src/storage/kv.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use sled::{Config as DbConfig, Db};
 
 use crate::{
-    broker::{BrokerEvent, ChBrokerSend, Destination},
+    broker::{BrokerEvent, BrokerMessage, ChBrokerSend, Destination},
     error::Error,
     storage::indexes::Indexes,
     Result,
@@ -286,7 +286,10 @@ impl KvStorage {
 
         // Publish a notification that the feed belonging to the given public
         // key has been updated.
-        let broker_msg = BrokerEvent::new(Destination::Broadcast, StoKvEvent::IdChanged(author));
+        let broker_msg = BrokerEvent::new(
+            Destination::Broadcast,
+            BrokerMessage::StoKv(StoKvEvent::IdChanged(author)),
+        );
 
         // Matching on the error here (instead of unwrapping) allows us to
         // write unit tests for `append_feed`; a case where we do not have

--- a/solar/src/storage/kv.rs
+++ b/solar/src/storage/kv.rs
@@ -24,7 +24,8 @@ const PREFIX_BLOB: u8 = 3u8;
 const PREFIX_PEER: u8 = 4u8;
 
 #[derive(Debug, Clone)]
-pub enum StoKvEvent {
+// TODO: Make this a tuple struct.
+pub enum StoreKvEvent {
     IdChanged(String),
 }
 
@@ -288,7 +289,7 @@ impl KvStorage {
         // key has been updated.
         let broker_msg = BrokerEvent::new(
             Destination::Broadcast,
-            BrokerMessage::StoKv(StoKvEvent::IdChanged(author)),
+            BrokerMessage::StoreKv(StoreKvEvent::IdChanged(author)),
         );
 
         // Matching on the error here (instead of unwrapping) allows us to


### PR DESCRIPTION
The primary change introduced in this PR is the conversion of `BrokerMessage` from a generic definition (`Arc<dyn Any + Send + Sync>`) to an `enum`. While the generic approach is convenient, it requires the message to be downcast each time a match occurs - usually as a reference. The change allows for more compact matching and should also open the door for a refactor of the connection and replication flow (more to come on that in a future PR).

Other minor changes:

- Replace single variant enums with tuple structs
- Variable renaming (ie. `StoBlobEvent` -> `StoreBlobEvent` etc.)
- Replace `*` imports with explicit imports (from `broker` module)