### PR TITLE
Event driven connections with message passing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1065,8 +1065,6 @@ dependencies = [
 [[package]]
 name = "kuska-handshake"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33da4b69f23c2ece0b3e729d079cebdc2c0206e493e42f510f500ad81c631d5"
 dependencies = [
  "futures",
  "hex",
@@ -1089,7 +1087,6 @@ dependencies = [
 [[package]]
 name = "kuska-ssb"
 version = "0.4.2"
-source = "git+https://github.com/Kuska-ssb/ssb?branch=master#7e1c633136380e8d83e6d239ed3c67f53f68abe9"
 dependencies = [
  "async-std",
  "async-stream",

--- a/solar/Cargo.toml
+++ b/solar/Cargo.toml
@@ -17,7 +17,8 @@ futures = "0.3"
 hex = "0.4.0"
 jsonrpsee = { version = "0.18.2", features = ["server"] }
 kuska-sodiumoxide = "0.2.5-0"
-kuska-ssb = { git =  "https://github.com/Kuska-ssb/ssb", branch = "master" }
+#kuska-ssb = { git =  "https://github.com/Kuska-ssb/ssb", branch = "master" }
+kuska-ssb = { path =  "../../ssb" }
 log = "0.4"
 once_cell = "1.16"
 rand = "0.8"

--- a/solar/src/actors/muxrpc/history_stream.rs
+++ b/solar/src/actors/muxrpc/history_stream.rs
@@ -19,6 +19,7 @@ use crate::{
     },
     broker::{BrokerEvent, BrokerMessage, ChBrokerSend, Destination},
     config::{PEERS_TO_REPLICATE, RESYNC_CONFIG, SECRET_CONFIG},
+    error::Error,
     node::BLOB_STORE,
     node::KV_STORE,
     storage::kv::StoreKvEvent,
@@ -125,29 +126,35 @@ where
             debug!("initializing history stream handler");
 
             // If local database resync has been selected...
-            if *RESYNC_CONFIG.get().unwrap() {
+            if *RESYNC_CONFIG.get().ok_or(Error::OptionIsNone)? {
                 info!("database resync selected; requesting local feed from peers");
                 // Read the local public key from the secret config file.
-                let local_public_key = &SECRET_CONFIG.get().unwrap().public_key;
+                // The public key is @-prefixed (at-prefixed).
+                let local_public_key = &SECRET_CONFIG.get().ok_or(Error::OptionIsNone)?.public_key;
                 // Create a history stream request for the local feed.
-                let args = dto::CreateHistoryStreamIn::new(local_public_key.clone()).after_seq(1);
+                let args =
+                    dto::CreateHistoryStreamIn::new(local_public_key.to_owned()).after_seq(1);
                 let req_id = api.create_history_stream_req_send(&args).await?;
 
                 // Insert the history stream request ID and peer public key
                 // into the peers hash map.
-                self.peers.insert(req_id, local_public_key.to_string());
+                self.peers.insert(req_id, local_public_key.to_owned());
             }
 
             // Loop through the public keys of all peers in the replication list.
             for peer_pk in PEERS_TO_REPLICATE.get().unwrap().keys() {
+                // Prefix `@` to public key.
+                let peer_public_key = format!("@{}", peer_pk);
+
                 // Instantiate the history stream request args for the given peer.
                 // The `live` arg means: keep the connection open after initial
                 // replication.
-                let mut args = dto::CreateHistoryStreamIn::new(format!("@{}", peer_pk)).live(true);
+                let mut args =
+                    dto::CreateHistoryStreamIn::new(peer_public_key.to_owned()).live(true);
 
                 // Retrieve the sequence number of the most recent message for
                 // this peer from the local key-value store.
-                if let Some(last_seq) = KV_STORE.read().await.get_latest_seq(peer_pk)? {
+                if let Some(last_seq) = KV_STORE.read().await.get_latest_seq(&peer_public_key)? {
                     // Use the latest sequence number to update the request args.
                     args = args.after_seq(last_seq);
                 }
@@ -157,11 +164,11 @@ where
 
                 // Insert the history stream request ID and peer ID
                 // (public key) into the peers hash map.
-                self.peers.insert(id, peer_pk.to_string());
+                self.peers.insert(id, peer_public_key.to_owned());
 
                 info!(
                     "requesting messages authored by peer {} after {:?}",
-                    peer_pk, args.seq
+                    peer_public_key, args.seq
                 );
             }
 
@@ -254,6 +261,10 @@ where
                     msg.sequence(),
                     last_seq
                 );
+
+                // Return to avoid handling multiple successive out-of-order
+                // messages.
+                return Ok(true);
             }
 
             Ok(true)

--- a/solar/src/actors/network/connection.rs
+++ b/solar/src/actors/network/connection.rs
@@ -135,6 +135,7 @@ pub async fn actor(
                         connection_data,
                         identity,
                         selective_replication,
+                        true, // Listener.
                     )),
                 ))
                 .await?;

--- a/solar/src/actors/network/connection.rs
+++ b/solar/src/actors/network/connection.rs
@@ -4,7 +4,10 @@ use async_std::net::TcpStream;
 use futures::SinkExt;
 use kuska_ssb::{
     crypto::{ed25519, ToSsbId},
-    handshake::async_std::{handshake_client, handshake_server},
+    handshake::{
+        async_std::{handshake_client, handshake_server},
+        HandshakeComplete,
+    },
     keystore::OwnedIdentity,
 };
 use log::info;
@@ -27,6 +30,15 @@ pub enum TcpConnection {
     },
     /// An inbound TCP connection.
     Listen { stream: TcpStream },
+}
+
+/// Stream data.
+#[derive(Debug, Clone)]
+pub struct StreamData {
+    /// Completed secret handshake.
+    pub handshake: HandshakeComplete,
+    /// TCP stream.
+    pub stream: TcpStream,
 }
 
 /// Connection data.
@@ -94,8 +106,200 @@ pub async fn actor(
     // Record the data associated with this connection.
     let connection_data = ConnectionData::new(connection_id, None, None);
 
-    let mut ch_broker = BROKER.lock().await.create_sender();
+    // Register the "connection" actor endpoint with the broker.
+    let ActorEndpoint { mut ch_broker, .. } =
+        BROKER.lock().await.register("connection", true).await?;
 
+    // Parse the public key and secret key from the SSB identity.
+    //let OwnedIdentity { pk, sk, .. } = identity;
+
+    /*
+    // Define the network key to be used for the secret handshake.
+    let network_key = NETWORK_KEY.get().unwrap().to_owned();
+    */
+
+    // Handle a TCP connection event (inbound or outbound).
+    match connection {
+        // Handle an outbound TCP connection event.
+        TcpConnection::Dial { addr, public_key } => {
+            // Update the data associated with this connection.
+            connection_data.peer_addr = Some(addr.to_owned());
+            connection_data.peer_public_key = Some(public_key);
+
+            // Send 'connecting' connection event message via the broker.
+            ch_broker
+                .send(BrokerEvent::new(
+                    Destination::Broadcast,
+                    ConnectionEvent::Connecting(connection_data.to_owned()),
+                ))
+                .await?;
+
+            /*
+
+            // Attempt a TCP connection.
+            let mut stream = TcpStream::connect(addr).await?;
+
+            // Send 'handshaking' connection event message via the broker.
+            ch_broker
+                .send(BrokerEvent::new(
+                    Destination::Broadcast,
+                    ConnectionEvent::Handshaking(connection_data.to_owned()),
+                ))
+                .await?;
+
+            // Attempt a secret handshake.
+            let handshake =
+                handshake_client(&mut stream, network_key.to_owned(), pk, sk, public_key).await?;
+
+            info!("💃 connected to peer {}", handshake.peer_pk.to_ssb_id());
+
+            // Encapsulate the completed handshake and the TCP stream;
+            // to be sent to the connection manager.
+            let stream_data = StreamData { handshake, stream };
+
+            // Send 'connected' connection event message via the broker.
+            ch_broker
+                .send(BrokerEvent::new(
+                    Destination::Broadcast,
+                    ConnectionEvent::Connected(connection_data.to_owned(), stream_data),
+                ))
+                .await?;
+            */
+        }
+        // Handle an incoming TCP connection event.
+        TcpConnection::Listen { mut stream } => {
+            // Retrieve the origin (address) of the incoming connection.
+            let peer_addr = stream.peer_addr()?.to_string();
+
+            // Update the data associated with this connection.
+            connection_data.peer_addr = Some(peer_addr);
+            connection_data.peer_public_key = None;
+
+            // Since the connection has been established, the handshake can
+            // now be attempted.
+
+            // Send 'handshaking' connection event message via the broker.
+            ch_broker
+                .send(BrokerEvent::new(
+                    Destination::Broadcast,
+                    ConnectionEvent::Handshaking(
+                        connection_data.to_owned(),
+                        stream,
+                        selective_replication,
+                    ),
+                ))
+                .await?;
+
+            /*
+            // Send 'connecting' connection event message via the broker.
+            ch_broker
+                .send(BrokerEvent::new(
+                    Destination::Broadcast,
+                    ConnectionEvent::Connecting(connection_data.to_owned()),
+                ))
+                .await?;
+
+            // Send 'handshaking' connection event message via the broker.
+            ch_broker
+                .send(BrokerEvent::new(
+                    Destination::Broadcast,
+                    ConnectionEvent::Handshaking(connection_data.to_owned()),
+                ))
+                .await?;
+
+            // Attempt a secret handshake.
+            let handshake = handshake_server(&mut stream, network_key.to_owned(), pk, sk).await?;
+
+            // Convert the public key to a `String`.
+            let ssb_id = handshake.peer_pk.to_ssb_id();
+
+            // Add the sigil link ('@') if it's missing.
+            let peer_public_key = if ssb_id.starts_with('@') {
+                ssb_id
+            } else {
+                format!("@{ssb_id}")
+            };
+
+            // Update the connection data to include the public key of the
+            // remote peer (sourced from the successful handshake data).
+            connection_data.peer_public_key = Some(handshake.peer_pk.to_owned());
+
+            // Encapsulate the completed handshake and the TCP stream;
+            // to be sent to the connection manager.
+            let stream_data = StreamData { handshake, stream };
+
+            // Send 'connected' connection event message via the broker.
+            ch_broker
+                .send(BrokerEvent::new(
+                    Destination::Broadcast,
+                    ConnectionEvent::Connected(connection_data.to_owned(), stream_data),
+                ))
+                .await?;
+
+            // TODO: Move this check into the connection manager.
+            // Specifically, inside the Connected event handler.
+            //
+            // Check if we are already connected to the selected peer.
+            // If yes, return immediately.
+            // If no, return the stream and handshake.
+            if CONNECTION_MANAGER
+                .read()
+                .await
+                .contains_connected_peer(&handshake.peer_pk)
+            {
+                info!("peer {} is already connected", &peer_public_key);
+
+                // Since we already have an active connection to this peer,
+                // we can disconnect the redundant connection.
+
+                // Send 'disconnecting' connection event message via the broker.
+                ch_broker
+                    .send(BrokerEvent::new(
+                        Destination::Broadcast,
+                        ConnectionEvent::Disconnecting(connection_data.to_owned()),
+                    ))
+                    .await?;
+
+                return Ok(connection_data);
+            }
+
+            info!("💃 received connection from peer {}", &peer_public_key);
+
+            // Shutdown the connection if the peer is not in the list of peers
+            // to be replicated, unless replication is set to nonselective.
+            // This ensures we do not replicate with unknown peers.
+            if selective_replication
+                & !PEERS_TO_REPLICATE
+                    .get()
+                    .unwrap()
+                    .contains_key(&peer_public_key)
+            {
+                info!(
+                    "peer {} is not in replication list and selective replication is enabled; dropping connection",
+                    peer_public_key
+                );
+
+                // Send connection event message via the broker.
+                ch_broker
+                    .send(BrokerEvent::new(
+                        Destination::Broadcast,
+                        ConnectionEvent::Disconnecting(connection_data.to_owned()),
+                    ))
+                    .await?;
+
+                // This may not be necessary; the connection should close when
+                // the stream is dropped.
+                stream.shutdown(Shutdown::Both)?;
+
+                return Ok(connection_data);
+            }
+
+            (stream, handshake)
+            */
+        }
+    };
+
+    /*
     // Attempt a connection and secret handshake.
     let connection_result = actor_inner(
         identity,
@@ -126,9 +330,12 @@ pub async fn actor(
                 .await?;
         }
     }
+    */
 
     Ok(())
 }
+
+/*
 
 /// Handle a TCP connection with a peer, perform the secret handshake
 /// and spawn the replication actor endpoint if the handshake is successful.
@@ -137,7 +344,7 @@ pub async fn actor_inner(
     connection: TcpConnection,
     mut connection_data: ConnectionData,
     selective_replication: bool,
-) -> Result<ConnectionData> {
+) -> Result<()> {
     // Register the "connection" actor endpoint with the broker.
     let ActorEndpoint { mut ch_broker, .. } =
         BROKER.lock().await.register("connection", true).await?;
@@ -149,7 +356,7 @@ pub async fn actor_inner(
     let network_key = NETWORK_KEY.get().unwrap().to_owned();
 
     // Handle a TCP connection event (inbound or outbound).
-    let (stream, handshake) = match connection {
+    match connection {
         // Handle an outbound TCP connection event.
         TcpConnection::Dial { addr, public_key } => {
             // Update the data associated with this connection.
@@ -181,15 +388,17 @@ pub async fn actor_inner(
 
             info!("💃 connected to peer {}", handshake.peer_pk.to_ssb_id());
 
+            // Encapsulate the completed handshake and the TCP stream;
+            // to be sent to the connection manager.
+            let stream_data = StreamData { handshake, stream };
+
             // Send 'connected' connection event message via the broker.
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Connected(connection_data.to_owned()),
+                    ConnectionEvent::Connected(connection_data.to_owned(), stream_data),
                 ))
                 .await?;
-
-            (stream, handshake)
         }
         // Handle an incoming TCP connection event.
         TcpConnection::Listen { mut stream } => {
@@ -234,14 +443,21 @@ pub async fn actor_inner(
             // remote peer (sourced from the successful handshake data).
             connection_data.peer_public_key = Some(handshake.peer_pk.to_owned());
 
+            // Encapsulate the completed handshake and the TCP stream;
+            // to be sent to the connection manager.
+            let stream_data = StreamData { handshake, stream };
+
             // Send 'connected' connection event message via the broker.
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Connected(connection_data.to_owned()),
+                    ConnectionEvent::Connected(connection_data.to_owned(), stream_data),
                 ))
                 .await?;
 
+            // TODO: Move this check into the connection manager.
+            // Specifically, inside the Connected event handler.
+            //
             // Check if we are already connected to the selected peer.
             // If yes, return immediately.
             // If no, return the stream and handshake.
@@ -304,6 +520,10 @@ pub async fn actor_inner(
     // Parse the peer public key from the handshake.
     let peer_public_key = handshake.peer_pk;
 
+    // TODO: Move this to the connection manager.
+    // First try EBT replication and fallback to classic replication
+    // if that fails.
+
     // Spawn the classic replication actor and await the result.
     Broker::spawn(crate::actors::replication::classic::actor(
         connection_data.to_owned(),
@@ -316,3 +536,4 @@ pub async fn actor_inner(
 
     Ok(connection_data)
 }
+*/

--- a/solar/src/actors/network/connection.rs
+++ b/solar/src/actors/network/connection.rs
@@ -1,3 +1,10 @@
+//! Handle inbound and outbound TCP connections.
+//!
+//! Inbound connections originate in the TCP server module, while outbound
+//! connection attempts are intiated by the connection scheduler module.
+//!
+//! Connection events are emitted and handled by the connection manager.
+
 use std::fmt::Display;
 
 use async_std::net::TcpStream;

--- a/solar/src/actors/network/connection.rs
+++ b/solar/src/actors/network/connection.rs
@@ -104,7 +104,7 @@ pub async fn actor(
     let connection_id = CONNECTION_MANAGER.write().await.register();
 
     // Record the data associated with this connection.
-    let connection_data = ConnectionData::new(connection_id, None, None);
+    let mut connection_data = ConnectionData::new(connection_id, None, None);
 
     // Register the "connection" actor endpoint with the broker.
     let ActorEndpoint { mut ch_broker, .. } =
@@ -130,7 +130,11 @@ pub async fn actor(
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    ConnectionEvent::Connecting(connection_data.to_owned()),
+                    ConnectionEvent::Connecting(
+                        connection_data.to_owned(),
+                        identity,
+                        selective_replication,
+                    ),
                 ))
                 .await?;
 
@@ -184,7 +188,8 @@ pub async fn actor(
                     Destination::Broadcast,
                     ConnectionEvent::Handshaking(
                         connection_data.to_owned(),
-                        stream,
+                        identity,
+                        &mut stream,
                         selective_replication,
                     ),
                 ))

--- a/solar/src/actors/network/connection_manager.rs
+++ b/solar/src/actors/network/connection_manager.rs
@@ -1,3 +1,14 @@
+//! Event-driven connection manager.
+//!
+//! The connection manager serves to register new TCP connections and handle
+//! each connection as it passes through several phases (eg. connection
+//! establishment, handshake, replication etc.).
+//!
+//! An event loop listens for connection events and executes handlers for each.
+//!
+//! Connection data, including the underlying TCP stream, is passed around with
+//! each event variant - allowing the handlers to take ownership of the data.
+
 use std::{collections::HashSet, net::Shutdown};
 
 use async_std::{

--- a/solar/src/actors/network/connection_scheduler.rs
+++ b/solar/src/actors/network/connection_scheduler.rs
@@ -207,7 +207,7 @@ pub async fn actor(peers: Vec<(PublicKey, String)>) -> Result<()> {
                 if let Some(msg) = msg {
                     if let Some(conn_event) = msg.downcast_ref::<ConnectionEvent>() {
                         match conn_event {
-                            ConnectionEvent::Replicating(data) => {
+                            ConnectionEvent::Replicating(data, _) => {
                                 // This connection was "successful".
                                 // Push the peer to the back of the eager queue.
                                 if let Some(public_key) = data.peer_public_key {

--- a/solar/src/broker.rs
+++ b/solar/src/broker.rs
@@ -14,12 +14,17 @@ use futures::{
 use log::{info, trace};
 use once_cell::sync::Lazy;
 
-use crate::Result;
+use crate::{actors::network::connection_manager::ConnectionEvent, Result};
 
 #[derive(Debug)]
 pub struct Void {}
 
-pub type BrokerMessage = Arc<dyn Any + Send + Sync>;
+// TODO: What if we make this into an enum and do away with `Arc`
+// and `Any`?
+//pub type BrokerMessage = Arc<dyn Any + Send + Sync>;
+pub enum BrokerMessage {
+    ConnectionEvent(ConnectionEvent),
+}
 
 pub type ChBrokerSend = mpsc::UnboundedSender<BrokerEvent>;
 pub type ChSigSend = oneshot::Sender<Void>;

--- a/solar/src/error.rs
+++ b/solar/src/error.rs
@@ -37,6 +37,8 @@ pub enum Error {
     MessageType(String),
     /// SSB RPC error.
     MuxRpc(rpc::Error),
+    /// None error (expected an `Option` to be `Some`).
+    OptionIsNone,
     /// Secret handshake error.
     SecretHandshake(handshake::async_std::Error),
     /// Serde CBOR error.
@@ -80,6 +82,7 @@ impl fmt::Display for Error {
             Error::LanDiscovery(err) => write!(f, "LAN UDP discovery error: {err}"),
             Error::MessageType(err) => write!(f, "SSB message type field error: {err}"),
             Error::MuxRpc(err) => write!(f, "MUXRPC error: {err}"),
+            Error::OptionIsNone => write!(f, "None error: expected Some"),
             Error::SecretHandshake(err) => write!(f, "Secret handshake error: {err}"),
             Error::SerdeCbor(err) => write!(f, "Serde CBOR error: {err}"),
             Error::SerdeJson(err) => write!(f, "Serde JSON error: {err}"),

--- a/solar/src/error.rs
+++ b/solar/src/error.rs
@@ -38,6 +38,7 @@ pub enum Error {
     /// SSB RPC error.
     MuxRpc(rpc::Error),
     /// None error (expected an `Option` to be `Some`).
+    // TODO: Add context String.
     OptionIsNone,
     /// Secret handshake error.
     SecretHandshake(handshake::async_std::Error),

--- a/solar_cli/Cargo.toml
+++ b/solar_cli/Cargo.toml
@@ -19,7 +19,8 @@ clap = { version = "4.1.8", features = ["derive"] }
 env_logger = "0.10"
 hex = "0.4.0"
 kuska-sodiumoxide = "0.2.5-0"
-kuska-ssb = { git =  "https://github.com/Kuska-ssb/ssb", branch = "master" }
+#kuska-ssb = { git =  "https://github.com/Kuska-ssb/ssb", branch = "master" }
+kuska-ssb = { path =  "../../ssb" }
 log = "0.4"
 url = "2.3"
 


### PR DESCRIPTION
This PR introduces a major refactor of the TCP connection life-cycle handling.

Connection data (including the TCP stream) is now passed to the connection manager and each phase of the cycle is handled there. This deviates from the previous approach where data was passed between various methods and the connection manager was mostly playing the role of registering connections and logging the steps. The connection life-cycle should now be easier to follow.

The refactor was prompted by my early explorations into adding EBT support. I soon realised that I needed to be able to take ownership of the stream in order to run an EBT loop.

Replication has been successfully tested between two `solar` instances and a `solar` and `Patchwork` instance.