### PR TITLE
Request blobs from EBT msgs

### DIFF
--- a/solar/src/actors/muxrpc/blobs_get.rs
+++ b/solar/src/actors/muxrpc/blobs_get.rs
@@ -21,26 +21,6 @@ use crate::{
     Result,
 };
 
-/// Regex pattern used to match blob references.
-pub static BLOB_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(&[0-9A-Za-z/+=]*.sha256)").unwrap());
-
-/// Extract blob references from post-type messages.
-pub fn extract_blob_refs(msg: &Message) -> Vec<String> {
-    let mut refs = Vec::new();
-
-    let msg = serde_json::from_value(msg.content().clone());
-
-    if let Ok(TypedMessage::Post { text, .. }) = msg {
-        for cap in BLOB_REGEX.captures_iter(&text) {
-            let key = cap.get(0).unwrap().as_str().to_owned();
-            refs.push(key);
-        }
-    }
-
-    refs
-}
-
 #[derive(Debug, Clone)]
 pub struct RpcBlobsGetEvent(pub dto::BlobsGetIn);
 

--- a/solar/src/actors/muxrpc/blobs_get.rs
+++ b/solar/src/actors/muxrpc/blobs_get.rs
@@ -21,6 +21,26 @@ use crate::{
     Result,
 };
 
+/// Regex pattern used to match blob references.
+pub static BLOB_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(&[0-9A-Za-z/+=]*.sha256)").unwrap());
+
+/// Extract blob references from post-type messages.
+pub fn extract_blob_refs(msg: &Message) -> Vec<String> {
+    let mut refs = Vec::new();
+
+    let msg = serde_json::from_value(msg.content().clone());
+
+    if let Ok(TypedMessage::Post { text, .. }) = msg {
+        for cap in BLOB_REGEX.captures_iter(&text) {
+            let key = cap.get(0).unwrap().as_str().to_owned();
+            refs.push(key);
+        }
+    }
+
+    refs
+}
+
 #[derive(Debug, Clone)]
 pub struct RpcBlobsGetEvent(pub dto::BlobsGetIn);
 

--- a/solar/src/actors/replication/blobs.rs
+++ b/solar/src/actors/replication/blobs.rs
@@ -1,0 +1,23 @@
+use kuska_ssb::{api::dto::content::TypedMessage, feed::Message};
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Regex pattern used to match blob references.
+pub static BLOB_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(&[0-9A-Za-z/+=]*.sha256)").unwrap());
+
+/// Extract blob references from post-type messages.
+pub fn extract_blob_refs(msg: &Message) -> Vec<String> {
+    let mut refs = Vec::new();
+
+    let msg = serde_json::from_value(msg.content().clone());
+
+    if let Ok(TypedMessage::Post { text, .. }) = msg {
+        for cap in BLOB_REGEX.captures_iter(&text) {
+            let key = cap.get(0).unwrap().as_str().to_owned();
+            refs.push(key);
+        }
+    }
+
+    refs
+}

--- a/solar/src/actors/replication/mod.rs
+++ b/solar/src/actors/replication/mod.rs
@@ -1,3 +1,4 @@
+pub mod blobs;
 pub mod classic;
 pub mod config;
 pub mod ebt;


### PR DESCRIPTION
- Move the blob reference extraction code out of `history_stream` and into the `blobs` replication module
- Extract blob references from messages received via EBT
- Call `"blob, get"` for any extracted references that are not already available locally