### PR TITLE
Send partial vector clock when local KV store is updated

### DIFF
--- a/solar/src/actors/muxrpc/ebt.rs
+++ b/solar/src/actors/muxrpc/ebt.rs
@@ -47,7 +47,7 @@ where
         peer_ssb_id: String,
         active_request: Option<ReqNo>,
     ) -> Result<bool> {
-        trace!(target: "ebt-handler", "Received MUXRPC input: {:?}", op);
+        trace!(target: "muxrpc-ebt-handler", "Received MUXRPC input: {:?}", op);
 
         // An outbound EBT replicate request was made before the handler was
         // called; add it to the map of active requests.

--- a/solar/src/actors/muxrpc/history_stream.rs
+++ b/solar/src/actors/muxrpc/history_stream.rs
@@ -85,7 +85,7 @@ where
                 self.recv_error_response(api, *req_no, err).await
             }
             // Handle a broker message.
-            RpcInput::Message(BrokerMessage::StoreKv(StoreKvEvent(id))) => {
+            RpcInput::Message(BrokerMessage::StoreKv(StoreKvEvent((id, _msg)))) => {
                 // Notification from the key-value store indicating that
                 // a new message has just been appended to the feed
                 // identified by `id`.

--- a/solar/src/actors/muxrpc/history_stream.rs
+++ b/solar/src/actors/muxrpc/history_stream.rs
@@ -85,11 +85,11 @@ where
                 self.recv_error_response(api, *req_no, err).await
             }
             // Handle a broker message.
-            RpcInput::Message(BrokerMessage::StoreKv(StoreKvEvent((id, _msg)))) => {
+            RpcInput::Message(BrokerMessage::StoreKv(StoreKvEvent(ssb_id))) => {
                 // Notification from the key-value store indicating that
                 // a new message has just been appended to the feed
-                // identified by `id`.
-                return self.recv_storageevent_idchanged(api, id).await;
+                // identified by `ssb_id`.
+                return self.recv_storageevent_idchanged(api, ssb_id).await;
             }
             // Handle a timer event.
             RpcInput::Timer => self.on_timer(api).await,
@@ -315,14 +315,14 @@ where
     async fn recv_storageevent_idchanged(
         &mut self,
         api: &mut ApiCaller<W>,
-        id: &str,
+        ssb_id: &str,
     ) -> Result<bool> {
         // Attempt to remove the peer from the list of active streams.
-        if let Some(mut req) = self.reqs.remove(id) {
+        if let Some(mut req) = self.reqs.remove(ssb_id) {
             // Send local messages to the peer.
             self.send_history(api, &mut req).await?;
             // Reinsert the peer into the list of active streams.
-            self.reqs.insert(id.to_string(), req);
+            self.reqs.insert(ssb_id.to_string(), req);
             Ok(true)
         } else {
             Ok(false)

--- a/solar/src/actors/replication/ebt/manager.rs
+++ b/solar/src/actors/replication/ebt/manager.rs
@@ -207,8 +207,8 @@ impl EbtManager {
             self.local_clock.insert(peer_id.to_owned(), encoded_value);
         } else {
             // No messages are stored in the local database for this feed.
-            // Set replicate flag to `true`, receive to `false` and `seq` to 0.
-            let encoded_value: EncodedClockValue = clock::encode(true, Some(false), Some(0))?;
+            // Set replicate flag to `true`, receive to `true` and `seq` to 0.
+            let encoded_value: EncodedClockValue = clock::encode(true, Some(true), Some(0))?;
             self.local_clock.insert(peer_id.to_owned(), encoded_value);
         }
 
@@ -252,7 +252,7 @@ impl EbtManager {
         if encoded_seq_no != -1 {
             if let (_replicate_flag, Some(true), Some(seq)) = clock::decode(encoded_seq_no)? {
                 if let Some(last_seq) = KV_STORE.read().await.get_latest_seq(feed_id)? {
-                    for n in seq..(last_seq + 1) {
+                    for n in (seq + 1)..=last_seq {
                         if let Some(msg_kvt) = KV_STORE.read().await.get_msg_kvt(feed_id, n)? {
                             messages.push(msg_kvt.value)
                         }

--- a/solar/src/actors/replication/ebt/manager.rs
+++ b/solar/src/actors/replication/ebt/manager.rs
@@ -484,6 +484,15 @@ impl EbtManager {
     }
 
     async fn handle_local_store_updated(&self, ssb_id: SsbId, msg: Value) -> Result<()> {
+        // TODO: Beware of a possible race condition in this implementation.
+        //
+        // We are not considering the sequence number of the last message sent
+        // to any active sessions for the given feed (ie. `ssb_id`).
+        //
+        // This means that we may inadvertently end up sending out-of-order
+        // messages if this message is sent before the rest of the requested
+        // feed history.
+
         // Create channel to send messages to broker.
         let mut ch_broker = BROKER.lock().await.create_sender();
 

--- a/solar/src/storage/kv.rs
+++ b/solar/src/storage/kv.rs
@@ -2,6 +2,7 @@ use futures::SinkExt;
 use kuska_ssb::feed::{Feed as MessageKvt, Message as MessageValue};
 use log::{debug, warn};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use sled::{Config as DbConfig, Db};
 
 use crate::{
@@ -25,8 +26,10 @@ const PREFIX_PEER: u8 = 4u8;
 
 /// The feed belonging to the given SSB ID has changed
 /// (ie. a new message has been appended to the feed).
+///
+/// The JSON value of the appended message is included.
 #[derive(Debug, Clone)]
-pub struct StoreKvEvent(pub String);
+pub struct StoreKvEvent(pub (String, Value));
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlobStatus {
@@ -285,7 +288,7 @@ impl KvStorage {
         // key has been updated.
         let broker_msg = BrokerEvent::new(
             Destination::Broadcast,
-            BrokerMessage::StoreKv(StoreKvEvent(author)),
+            BrokerMessage::StoreKv(StoreKvEvent((author, msg_kvt.value))),
         );
 
         // Matching on the error here (instead of unwrapping) allows us to

--- a/solar/src/storage/kv.rs
+++ b/solar/src/storage/kv.rs
@@ -2,7 +2,6 @@ use futures::SinkExt;
 use kuska_ssb::feed::{Feed as MessageKvt, Message as MessageValue};
 use log::{debug, warn};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use sled::{Config as DbConfig, Db};
 
 use crate::{
@@ -29,7 +28,7 @@ const PREFIX_PEER: u8 = 4u8;
 ///
 /// The JSON value of the appended message is included.
 #[derive(Debug, Clone)]
-pub struct StoreKvEvent(pub (String, Value));
+pub struct StoreKvEvent(pub String);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlobStatus {
@@ -288,7 +287,7 @@ impl KvStorage {
         // key has been updated.
         let broker_msg = BrokerEvent::new(
             Destination::Broadcast,
-            BrokerMessage::StoreKv(StoreKvEvent((author, msg_kvt.value))),
+            BrokerMessage::StoreKv(StoreKvEvent(author)),
         );
 
         // Matching on the error here (instead of unwrapping) allows us to


### PR DESCRIPTION
Listen for `StoreKvEvent`, indicating that a message has been appended to a feed in the local key-value store; retrieve the latest sequence number for the feed and send a partial vector clock for that feed to all active EBT sessions. This allows us to notify peers of changes to our replication state.

This PR also removes a redundant check for vector clocks in received MUXRPC requests. 