### PR TITLE
Load and persist peer vector clocks

### DIFF
--- a/solar/src/config.rs
+++ b/solar/src/config.rs
@@ -53,26 +53,29 @@ impl ApplicationConfig {
     /// Create the root data directory for solar, along with the feed and blob
     /// directories. This is where all application data is stored, including
     /// the public-private keypair, key-value database and blob store.
-    fn create_data_directories(path: Option<PathBuf>) -> Result<(PathBuf, PathBuf)> {
+    fn create_data_directories(path: Option<PathBuf>) -> Result<(PathBuf, PathBuf, PathBuf)> {
         let base_path = path.unwrap_or(BaseDirectories::new()?.create_data_directory("solar")?);
 
         // Define the directory name for the feed store.
         let feeds_path = base_path.join("feeds");
         // Define the directory name for the blob store.
         let blobs_path = base_path.join("blobs");
+        // Define the directory name for the EBT vector clocks.
+        let ebt_path = base_path.join("ebt");
 
-        // Create the feed and blobs directories.
+        // Create the feed, blobs and ebt directories.
         std::fs::create_dir_all(&feeds_path)?;
         std::fs::create_dir_all(blobs_path)?;
+        std::fs::create_dir_all(&ebt_path)?;
 
-        Ok((base_path, feeds_path))
+        Ok((base_path, feeds_path, ebt_path))
     }
 
     /// Configure the application based on CLI options, environment variables
     /// and defaults.
     pub fn new(path: Option<PathBuf>) -> Result<Self> {
         // Create the application data directories if they don't already exist.
-        let (base_path, feeds_path) = Self::create_data_directories(path)?;
+        let (base_path, feeds_path, _ebt_path) = Self::create_data_directories(path)?;
 
         info!("Base directory is {:?}", base_path);
 

--- a/solar/src/node.rs
+++ b/solar/src/node.rs
@@ -43,6 +43,7 @@ impl Node {
         // Define the directory name for the blob store.
         let blobs_path = config
             .base_path
+            .as_ref()
             .expect("Base path not supplied")
             .join("blobs");
 
@@ -136,11 +137,18 @@ impl Node {
         // intervals).
         Broker::spawn(connection_scheduler::actor(peers_to_dial));
 
+        // Define the directory name for the ebt clock store.
+        let ebt_path = config
+            .base_path
+            .expect("Base path not supplied")
+            .join("ebt");
+
         // Spawn the EBT replication manager actor.
         let ebt_replication_manager = EbtManager::default();
         Broker::spawn(EbtManager::event_loop(
             ebt_replication_manager,
             owned_identity.id,
+            ebt_path,
         ));
 
         // Spawn the connection manager message loop.


### PR DESCRIPTION
Following the same approach taken by `ssb-ebt` (used in Manyverse), we persist peer vector clocks to the `ebt` directory in the application's root configuration directory (`~/.local/share/solar` in the case of solar).

Each file is created using the @-prefixed SSB ID of the author as the filename; all instances of `/` are replaced with `-` and the `=` before `.ed25519` is removed. For example: `@HIYqoOhH6U-muCXsnvXzRQmoPpPXrELnJlqSjId2Fg8.ed25519`

The file then contains a JSON string of the vector clock for that peer. For example: `{"@HIYqoOhH6U+muCXsnvXzRQmoPpPXrELnJlqSjId2Fg8=.ed25519":32,"@HZnU6wM+F17J0RSLXP05x3Lag2jGv3F3LzHMjh72coE=.ed25519":7712}`

Clocks are loaded from file when the EBT manager starts and persisted to file just before it shuts down.