### PR TITLE
Improved EBT session tracking

### DIFF
--- a/solar/src/actors/network/connection.rs
+++ b/solar/src/actors/network/connection.rs
@@ -60,11 +60,14 @@ impl Display for TcpConnection {
     }
 }
 
+/// Unique ID for a connection.
+pub type ConnectionId = usize;
+
 /// Connection data.
 #[derive(Debug, Default, Clone)]
 pub struct ConnectionData {
     /// Connection identifier.
-    pub id: usize,
+    pub id: ConnectionId,
     /// The address of the remote peer.
     pub peer_addr: Option<String>,
     /// The public key of the remote peer.
@@ -105,7 +108,7 @@ impl Display for ConnectionData {
 }
 
 impl ConnectionData {
-    pub fn new(id: usize) -> Self {
+    pub fn new(id: ConnectionId) -> Self {
         ConnectionData {
             id,
             ..ConnectionData::default()

--- a/solar/src/actors/replication/ebt/manager.rs
+++ b/solar/src/actors/replication/ebt/manager.rs
@@ -44,19 +44,21 @@ use crate::{
     Error, Result,
 };
 
+type ErrorMsg = String;
+
 /// EBT replication events.
 #[derive(Debug, Clone)]
 pub enum EbtEvent {
     WaitForSessionRequest(ConnectionData),
     RequestSession(ConnectionData),
     SessionInitiated(ConnectionId, ReqNo, SsbId, SessionRole),
-    SendClock(ConnectionId, ReqNo, VectorClock),
-    SendMessage(ConnectionId, ReqNo, SsbId, Value),
+    SendClock(ConnectionId, ReqNo, VectorClock, SessionRole),
+    SendMessage(ConnectionId, ReqNo, SsbId, Value, SessionRole),
     ReceivedClock(ConnectionId, ReqNo, SsbId, VectorClock),
     ReceivedMessage(Message),
     SessionConcluded(ConnectionId, SsbId),
     SessionTimeout(ConnectionData, SsbId),
-    Error(ConnectionData, Option<ReqNo>, SsbId, String),
+    Error(ConnectionData, Option<ReqNo>, SsbId, ErrorMsg),
 }
 
 /// Role of a peer in an EBT session.
@@ -78,7 +80,7 @@ impl Display for SessionRole {
 #[derive(Debug)]
 pub struct EbtManager {
     /// Active EBT peer sessions.
-    active_sessions: HashSet<(ConnectionId, SsbId)>,
+    active_sessions: HashMap<ConnectionId, (SsbId, SessionRole)>,
     /// Duration to wait before switching feed request to a different peer.
     _feed_wait_timeout: u64,
     /// The state of the replication loop.
@@ -97,13 +99,12 @@ pub struct EbtManager {
     /// Duration to wait for a connected peer to initiate an EBT session.
     session_wait_timeout: u64,
     /// The latest vector clock sent for each session, identified by the
-    /// request number.
+    /// connection ID.
+    // TODO: Should we include the SsbId? Then we can track clocks sent to
+    // each peer across multiple sessions.
     //
-    // TODO: Do we want to remove each entry when the session concludes?
-    //
-    // TODO: Rather use connection ID as the key (req no is not unique
-    // across sessions).
-    sent_clocks: HashMap<ReqNo, VectorClock>,
+    // Based on current usage, this could just be a HashSet of ConnectionId.
+    sent_clocks: HashMap<ConnectionId, VectorClock>,
     /// The sequence number of the latest message sent to each peer
     /// for each requested feed.
     sent_messages: HashMap<SsbId, HashMap<SsbId, u64>>,
@@ -112,7 +113,7 @@ pub struct EbtManager {
 impl Default for EbtManager {
     fn default() -> Self {
         EbtManager {
-            active_sessions: HashSet::new(),
+            active_sessions: HashMap::new(),
             _feed_wait_timeout: 3,
             _is_replication_loop_active: false,
             local_clock: HashMap::new(),
@@ -280,20 +281,33 @@ impl EbtManager {
 
     /// Register a new EBT session for the given peer.
     //fn register_session(&mut self, peer_ssb_id: &SsbId, req_no: ReqNo, session_role: SessionRole) {
-    fn register_session(&mut self, connection_id: ConnectionId, peer_ssb_id: &SsbId) {
+    fn register_session(
+        &mut self,
+        connection_id: ConnectionId,
+        peer_ssb_id: &SsbId,
+        session_role: SessionRole,
+    ) {
         self.active_sessions
-            .insert((connection_id, peer_ssb_id.to_owned()));
+            .insert(connection_id, (peer_ssb_id.to_owned(), session_role));
 
         trace!(target: "ebt-session", "Registered new EBT session for connection {} with {}", connection_id, peer_ssb_id);
     }
 
     /// Remove the given peer from the list of active session.
-    fn remove_session(&mut self, connection_id: ConnectionId, peer_ssb_id: &SsbId) {
+    fn remove_session(&mut self, connection_id: ConnectionId) {
         // TODO: Clean-up the string story so we're not sprinkling additional
         // allocations everywhere.
-        let _ = self
-            .active_sessions
-            .remove(&(connection_id, peer_ssb_id.to_owned()));
+        let _ = self.active_sessions.remove(&connection_id);
+    }
+
+    /// Return the role of the local peer for the active session (represented
+    /// by connection ID).
+    fn session_role(&self, connection_id: ConnectionId) -> Option<SessionRole> {
+        if let Some((_ssb_id, session_role)) = self.active_sessions.get(&connection_id) {
+            Some(session_role.to_owned())
+        } else {
+            None
+        }
     }
 
     /// Revoke a replication request for the feed represented by the given SSB
@@ -390,14 +404,11 @@ impl EbtManager {
 
             // Only proceed with session initiation if there
             // is no currently active session with the given peer.
-            if !self
-                .active_sessions
-                .contains(&(connection_data.id, peer_ssb_id))
-            {
+            if !self.active_sessions.contains_key(&connection_data.id) {
                 trace!(
                     target: "ebt",
-                    "Requesting an EBT session with {:?}",
-                    connection_data.peer_public_key.unwrap()
+                    "Requesting an EBT session with {}",
+                    peer_ssb_id
                 );
 
                 task::spawn(replicator::run(
@@ -418,7 +429,7 @@ impl EbtManager {
     ) -> Result<()> {
         trace!(target: "ebt-replication", "Initiated EBT session with {} as {}", peer_ssb_id, session_role);
 
-        self.register_session(connection_id, &peer_ssb_id);
+        self.register_session(connection_id, &peer_ssb_id, session_role.to_owned());
         let local_clock = self.local_clock.to_owned();
 
         match session_role {
@@ -431,7 +442,12 @@ impl EbtManager {
                 ch_broker
                     .send(BrokerEvent::new(
                         Destination::Broadcast,
-                        BrokerMessage::Ebt(EbtEvent::SendClock(connection_id, req_no, local_clock)),
+                        BrokerMessage::Ebt(EbtEvent::SendClock(
+                            connection_id,
+                            req_no,
+                            local_clock,
+                            SessionRole::Responder,
+                        )),
                     ))
                     .await?;
             }
@@ -446,12 +462,10 @@ impl EbtManager {
 
     fn handle_send_clock(
         &mut self,
-        _connection_id: ConnectionId,
-        req_no: ReqNo,
+        connection_id: ConnectionId,
         clock: VectorClock,
     ) -> Option<VectorClock> {
-        // TODO: Include connection ID in sent clock tracking.
-        self.sent_clocks.insert(req_no, clock)
+        self.sent_clocks.insert(connection_id, clock)
     }
 
     async fn handle_received_clock(
@@ -469,40 +483,43 @@ impl EbtManager {
         // Create channel to send messages to broker.
         let mut ch_broker = BROKER.lock().await.create_sender();
 
-        // If a clock is received without a prior EBT replicate
-        // request having been received from the associated peer, it is
-        // assumed that the clock was sent in response to a locally-sent
-        // EBT replicate request. Ie. the session was requested by the
-        // local peer.
-        //
-        // TODO: Can we avoid the allocation on `peer_ssb_id`?
-        if !self
-            .active_sessions
-            .contains(&(connection_id, peer_ssb_id.to_owned()))
-        {
-            ch_broker
-                .send(BrokerEvent::new(
-                    Destination::Broadcast,
-                    BrokerMessage::Ebt(EbtEvent::SessionInitiated(
-                        connection_id,
-                        req_no,
-                        peer_ssb_id.to_owned(),
-                        SessionRole::Requester,
-                    )),
-                ))
-                .await?;
-        }
+        // TODO: What if we initiated a session as requester when sending
+        // replicate request? That might simply things.
+        let session_role = match self.session_role(connection_id) {
+            Some(role) => role,
+            None => {
+                ch_broker
+                    .send(BrokerEvent::new(
+                        Destination::Broadcast,
+                        BrokerMessage::Ebt(EbtEvent::SessionInitiated(
+                            connection_id,
+                            req_no,
+                            peer_ssb_id.to_owned(),
+                            SessionRole::Requester,
+                        )),
+                    ))
+                    .await?;
 
-        // If we have not previously sent a clock, send one now.
+                SessionRole::Requester
+            }
+        };
+
+        // If we have not previously sent a clock during this connection,
+        // send one now. Connection is used here as a proxy for session.
         //
         // This indicates that the local peer is acting as the session
         // requester.
-        if self.sent_clocks.get(&req_no).is_none() {
+        if self.sent_clocks.get(&connection_id).is_none() {
             let local_clock = self.local_clock.to_owned();
             ch_broker
                 .send(BrokerEvent::new(
                     Destination::Broadcast,
-                    BrokerMessage::Ebt(EbtEvent::SendClock(connection_id, req_no, local_clock)),
+                    BrokerMessage::Ebt(EbtEvent::SendClock(
+                        connection_id,
+                        req_no,
+                        local_clock,
+                        SessionRole::Requester,
+                    )),
                 ))
                 .await?;
         }
@@ -519,6 +536,7 @@ impl EbtManager {
                         req_no,
                         peer_ssb_id.to_owned(),
                         msg,
+                        session_role.to_owned(),
                     )),
                 ))
                 .await?;
@@ -642,7 +660,7 @@ impl EbtManager {
 
     async fn handle_session_concluded(&mut self, connection_id: ConnectionId, peer_ssb_id: SsbId) {
         trace!(target: "ebt-replication", "Session concluded for connection {} with {}", connection_id, peer_ssb_id);
-        self.remove_session(connection_id, &peer_ssb_id);
+        self.remove_session(connection_id);
     }
 
     async fn handle_session_timeout(
@@ -657,7 +675,7 @@ impl EbtManager {
         // for now out of caution.
         //
         // TODO: Remove this line when it's clear that it's not needed.
-        self.remove_session(connection_data.id, &peer_ssb_id);
+        self.remove_session(connection_data.id);
 
         // Create channel to send messages to broker.
         let mut ch_broker = BROKER.lock().await.create_sender();
@@ -678,34 +696,41 @@ impl EbtManager {
         connection_data: ConnectionData,
         req_no: Option<ReqNo>,
         peer_ssb_id: SsbId,
-        err_msg: String,
+        error_msg: ErrorMsg,
     ) -> Result<()> {
-        trace!(target: "ebt-replication", "Session error with {} for request number {:?}: {}", peer_ssb_id, req_no, err_msg);
+        trace!(target: "ebt-replication", "Session error with {} for request number {:?}: {}", peer_ssb_id, req_no, error_msg);
 
-        self.remove_session(connection_data.id, &peer_ssb_id);
+        self.remove_session(connection_data.id);
 
         // Create channel to send messages to broker.
         let mut ch_broker = BROKER.lock().await.create_sender();
 
-        ch_broker
-            .send(BrokerEvent::new(
-                Destination::Broadcast,
-                BrokerMessage::Connection(ConnectionEvent::Disconnecting(connection_data)),
-            ))
-            .await?;
-
-        // TODO: Match on error variant and fallback to class replication if
-        // the error was `Error::EbtReplicate`.
-
-        /*
-        // Fallback to classic replication.
-        ch_broker
-            .send(BrokerEvent::new(
-                Destination::Broadcast,
-                BrokerMessage::Connection(ConnectionEvent::ReplicatingClassic(connection_data)),
-            ))
-            .await?;
-        */
+        if error_msg.starts_with("Serde JSON error")
+            || error_msg.starts_with("EBT replication error")
+        {
+            // Either the received EBT replicate request was invalid or the sent
+            // EBT replicate request received an error response from the remote
+            // peer.
+            //
+            // Fallback to classic replication.
+            ch_broker
+                .send(BrokerEvent::new(
+                    Destination::Broadcast,
+                    BrokerMessage::Connection(ConnectionEvent::ReplicatingClassic(connection_data)),
+                ))
+                .await?;
+        } else {
+            // Something else went wrong. Kill the connection.
+            //
+            // TODO: In the future we may want to match on other specific error
+            // variants. For now, this is good enough.
+            ch_broker
+                .send(BrokerEvent::new(
+                    Destination::Broadcast,
+                    BrokerMessage::Connection(ConnectionEvent::Disconnecting(connection_data)),
+                ))
+                .await?;
+        }
 
         Ok(())
     }
@@ -754,9 +779,9 @@ impl EbtManager {
                                     error!("Error while handling 'session initiated' event: {}", err)
                                 }
                             }
-                            EbtEvent::SendClock(connection_id, req_no, clock) => {
+                            EbtEvent::SendClock(connection_id, _req_no, clock, _session_role) => {
                                 trace!(target: "ebt-replication", "Sending vector clock: {:?}", clock);
-                                let _ = self.handle_send_clock(connection_id, req_no, clock);
+                                let _ = self.handle_send_clock(connection_id, clock);
                             }
                             EbtEvent::ReceivedClock(connection_id, req_no, peer_ssb_id, clock) => {
                                 if let Err(err) = self.handle_received_clock(connection_id, req_no, peer_ssb_id, clock).await {
@@ -768,7 +793,7 @@ impl EbtManager {
                                     error!("Error while handling 'received message' event: {}", err)
                                 }
                             }
-                            EbtEvent::SendMessage(_connection_id, _req_no, peer_ssb_id, msg) => {
+                            EbtEvent::SendMessage(_connection_id, _req_no, peer_ssb_id, msg, _session_role) => {
                                 trace!(target: "ebt-replication", "Sending message: {:?}...", msg);
                                 if let Err(err) = self.handle_send_message(peer_ssb_id, msg).await {
                                     error!("Error while handling 'send message' event: {}", err)
@@ -782,8 +807,8 @@ impl EbtManager {
                                     error!("Error while handling 'session timeout' event: {}", err)
                                 }
                             }
-                            EbtEvent::Error(connection_data, req_no, peer_ssb_id, err_msg) => {
-                                if let Err(err) = self.handle_error(connection_data, req_no, peer_ssb_id, err_msg).await {
+                            EbtEvent::Error(connection_data, req_no, peer_ssb_id, error_msg) => {
+                                if let Err(err) = self.handle_error(connection_data, req_no, peer_ssb_id, error_msg).await {
                                     error!("Error while handling 'error' event: {}", err)
                                 }
                             }

--- a/solar/src/actors/replication/ebt/replicator.rs
+++ b/solar/src/actors/replication/ebt/replicator.rs
@@ -83,6 +83,7 @@ pub async fn run(
     // received.
     let ebt_session_start = Instant::now();
 
+    // TODO: Could this be moved into the MUXRPC EBT handler?
     if let SessionRole::Requester = session_role {
         // Send EBT request.
         let ebt_args = EbtReplicate::default();
@@ -136,27 +137,6 @@ pub async fn run(
             Err(err) => {
                 error!("EBT replicate handler failed: {:?}", err);
 
-                /*
-                // TODO: This match is not exhaustive.
-                //
-                // We end up in a situation where the connection is not
-                // cleaned up (`ConnectionEvent::Disconnecting`) and the
-                // session is not removed.
-                if let Error::EbtReplicate((req_no, err_msg)) = err {
-                    ch_broker
-                        .send(BrokerEvent::new(
-                            Destination::Broadcast,
-                            BrokerMessage::Ebt(EbtEvent::Error(
-                                connection_data,
-                                req_no,
-                                peer_ssb_id.to_owned(),
-                                err_msg,
-                            )),
-                        ))
-                        .await?;
-                }
-                */
-
                 ch_broker
                     .send(BrokerEvent::new(
                         Destination::Broadcast,
@@ -200,6 +180,8 @@ pub async fn run(
         }
     }
 
+    // TODO: Consider including session role in SessionConcluded so that we can
+    // await another request if acting as the responder.
     ch_broker
         .send(BrokerEvent::new(
             Destination::Broadcast,


### PR DESCRIPTION
Active EBT sessions were previously tracked primarily using the request ID. This becomes problematic when multiple EBT sessions are active at the same time, since every peer starts with request number 1. Since each new connection is assigned a unique ID, this provides a natural mechanism for more accurately associating session events with a given peer.

The connection ID is now included in `SendMessage` and `SendClock` events. The MUXRPC EBT handler, upon receiving such an event, can then compare the connection ID against the connection ID it was invoked with - acting only if the two match. Other running instances of the handler will simply ignore those events which were not intended for them.

Session tracking still needs more work but there are steps in the right direction.

This PR is also in the process of making improvements to the handling of `SessionConcluded`, `SessionTimeout` and `SessionError` events.

Perhaps most importantly, this PR fixes https://github.com/mycognosist/solar/issues/89

-----

There are still myriad entanglements between the EBT session manager and EBT MUXRPC handler; separation can come later. 