### PR TITLE
Introduce live message sending for EBT sessions

### DIFF
--- a/solar/src/actors/muxrpc/history_stream.rs
+++ b/solar/src/actors/muxrpc/history_stream.rs
@@ -85,7 +85,7 @@ where
                 self.recv_error_response(api, *req_no, err).await
             }
             // Handle a broker message.
-            RpcInput::Message(BrokerMessage::StoreKv(StoreKvEvent(ssb_id))) => {
+            RpcInput::Message(BrokerMessage::StoreKv(StoreKvEvent((ssb_id, _seq)))) => {
                 // Notification from the key-value store indicating that
                 // a new message has just been appended to the feed
                 // identified by `ssb_id`.

--- a/solar/src/storage/kv.rs
+++ b/solar/src/storage/kv.rs
@@ -23,12 +23,9 @@ const PREFIX_BLOB: u8 = 3u8;
 /// Prefix for a key to a peer.
 const PREFIX_PEER: u8 = 4u8;
 
-/// The feed belonging to the given SSB ID has changed
-/// (ie. a new message has been appended to the feed).
-///
-/// The JSON value of the appended message is included.
+/// A new message has been appended to feed belonging to the given SSB ID.
 #[derive(Debug, Clone)]
-pub struct StoreKvEvent(pub String);
+pub struct StoreKvEvent(pub (String, u64));
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlobStatus {
@@ -287,7 +284,7 @@ impl KvStorage {
         // key has been updated.
         let broker_msg = BrokerEvent::new(
             Destination::Broadcast,
-            BrokerMessage::StoreKv(StoreKvEvent(author)),
+            BrokerMessage::StoreKv(StoreKvEvent((author, seq_num))),
         );
 
         // Matching on the error here (instead of unwrapping) allows us to


### PR DESCRIPTION
While testing EBT I noticed that Manyverse sends messages of interest to active session peers immediately, instead of sending a partial vector clock indicating the update. This PR introduces that same behaviour to solar.

An event is emitted when the local key-value store is updated with a new message. The event includes the feed ID and the sequence number of the appended message. Those details are matched on in the EBT manager. If we have an active session with a peer interested in receiving messages from that feed, we send the message (as long as the sequence number is greater than the sequence number in the latest vector clock from that peer).

Live updates are now bidirectional when an EBT session is active between solar and Manyverse, as well as between two instances of solar.

