### PR TITLE
Send end-of-stream request to all active sessions before solar terminates

### DIFF
--- a/solar/src/actors/replication/ebt/manager.rs
+++ b/solar/src/actors/replication/ebt/manager.rs
@@ -60,6 +60,7 @@ pub enum EbtEvent {
     ReceivedMessage(Message),
     SessionConcluded(ConnectionId, SsbId),
     SessionTimeout(ConnectionData, SsbId),
+    TerminateSession(ConnectionId, SessionRole),
     Error(ConnectionData, SsbId, ErrorMsg),
 }
 
@@ -686,6 +687,10 @@ impl EbtManager {
         Ok(())
     }
 
+    async fn handle_terminate_session(&mut self, connection_id: ConnectionId) {
+        trace!(target: "ebt-replication", "Terminating session for connection {}", connection_id);
+    }
+
     async fn handle_error(
         &mut self,
         connection_data: ConnectionData,
@@ -800,6 +805,9 @@ impl EbtManager {
                                 if let Err(err) = self.handle_session_timeout(connection_data, peer_ssb_id).await {
                                     error!("Error while handling 'session timeout' event: {}", err)
                                 }
+                            }
+                            EbtEvent::TerminateSession(connection_data, _session_role) => {
+                                self.handle_terminate_session(connection_data).await;
                             }
                             EbtEvent::Error(connection_data, peer_ssb_id, error_msg) => {
                                 if let Err(err) = self.handle_error(connection_data, peer_ssb_id, error_msg).await {


### PR DESCRIPTION
This behaviour is not spec'd out for EBT so I'm simply following the defined behaviour for classic replication streams.

When `solar` receives a termination signal, any active EBT session peers are sent an RPC message with both the stream and end/err flags set and a JSON body of `true`. Upon receiving such a request, a `solar` peer will send one in response (this is probably unnecessary but seems like good practice nonetheless).

Manyverse does not appear to implement this behaviour; no end-of-stream RPC message is received when terminating Manyverse during an active session (at least not that I can detect). I would much rather have explicit communication in this case.