### PR TITLE
Fix JSON-RPC server params

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,31 +132,31 @@ While running, a solar node can be queried using JSON-RPC over HTTP.
 
 | Method | Parameters | Response | Description |
 | --- | --- | --- | --- |
-| `blocks` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
-| `blockers` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
-| `descriptions` | `"<@...=.ed25519>"` | `[<description>]` | Returns an array of descriptions |
-| `self_descriptions` | `"<@...=.ed25519>"` | `[<description>]` | Returns an array of descriptions |
-| `latest_description` | `"<@...=.ed25519>"` | `<description>` | Returns a single description |
-| `latest_self_description` | `"<@...=.ed25519>"` | `<description>` | Returns a single description |
-| `feed` | `"<@...=.ed25519>"` | `[{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }]` | Returns an array of message KVTs (key, value, timestamp) from the local database |
-| `follows` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
-| `followers` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
-| `is_following` | `{ "peer_a": "<@...=.ed25519>", "peer_b": "<@...=.ed25519>" }` | `[<@...=.ed25519>]` | Returns a boolean |
-| `friends` | `"<@...=.ed25519>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
-| `images` | `"<@...=.ed25519>"` | `[<&...=.sha256>]` | Returns an array of image references |
-| `self_images` | `"<@...=.ed25519>"` | `[<&...=.sha256>]` | Returns an array of image references |
-| `latest_image` | `"<@...=.ed25519>"` | `<&...=.sha256>` | Returns a single image reference |
-| `latest_self_image` | `"<@...=.ed25519>"` | `<&...=.sha256>` | Returns a single image reference |
-| `message` | `"<%...=.sha256>"` | `{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }` | Returns a single message KVT (key, value, timestamp) from the local database |
-| `names` | `"<@...=.ed25519>"` | `[<name>]` | Returns an array of names |
-| `self_names` | `"<@...=.ed25519>"` | `[<name>]` | Returns an array of names |
-| `latest_name` | `"<@...=.ed25519>"` | `<name>` | Returns a single name |
-| `latest_self_name` | `"<@...=.ed25519>"` | `<name>` | Returns a single name |
+| `blocks` | `["<@...=.ed25519>"]` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `blockers` | `["<@...=.ed25519>"]` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `descriptions` | `["<@...=.ed25519>"]` | `[<description>]` | Returns an array of descriptions |
+| `self_descriptions` | `["<@...=.ed25519>"]` | `[<description>]` | Returns an array of descriptions |
+| `latest_description` | `["<@...=.ed25519>"]` | `<description>` | Returns a single description |
+| `latest_self_description` | `["<@...=.ed25519>"]` | `<description>` | Returns a single description |
+| `feed` | `["<@...=.ed25519>"]` | `[{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }]` | Returns an array of message KVTs (key, value, timestamp) from the local database |
+| `follows` | `["<@...=.ed25519>"]` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `followers` | `["<@...=.ed25519>"]` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `is_following` | `["<@...=.ed25519>", "<@...=.ed25519>"]` | `<bool>` | Returns a boolean |
+| `friends` | `["<@...=.ed25519>"]` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `images` | `["<@...=.ed25519>"]` | `[<&...=.sha256>]` | Returns an array of image references |
+| `self_images` | `["<@...=.ed25519>"]` | `[<&...=.sha256>]` | Returns an array of image references |
+| `latest_image` | `["<@...=.ed25519>"]` | `<&...=.sha256>` | Returns a single image reference |
+| `latest_self_image` | `["<@...=.ed25519>"]` | `<&...=.sha256>` | Returns a single image reference |
+| `message` | `["<%...=.sha256>"]` | `{ "key": "<%...=.sha256>", "value": <value>, "timestamp": <timestamp>, "rts": null }` | Returns a single message KVT (key, value, timestamp) from the local database |
+| `names` | `["<@...=.ed25519>"]` | `[<name>]` | Returns an array of names |
+| `self_names` | `["<@...=.ed25519>"]` | `[<name>]` | Returns an array of names |
+| `latest_name` | `["<@...=.ed25519>"]` | `<name>` | Returns a single name |
+| `latest_self_name` | `["<@...=.ed25519>"]` | `<name>` | Returns a single name |
 | `peers` | | `[{ "pub_key": "<@...=.ed25519>", "seq_num": <int> }` | Returns an array of public key and latest sequence number for each peer in the local database |
 | `ping` | | `pong!` | Responds if the JSON-RPC server is running |
 | `publish` | `<content>` | `{ "msg_ref": "<%...=.sha256>", "seq_num": <int> }` | Publishes a message and returns the reference (message hash) and sequence number |
-| `subscribers` | `"<channel>"` | `[<@...=.ed25519>]` | Returns an array of public keys |
-| `subscriptions` | `"<@...=.ed25519>"` | `[<channel>]` | Returns an array of channel names |
+| `subscribers` | `["<channel>"]` | `[<@...=.ed25519>]` | Returns an array of public keys |
+| `subscriptions` | `["<@...=.ed25519>"]` | `[<channel>]` | Returns an array of channel names |
 | `whoami` | | `<@...=.ed25519>` | Returns the public key of the local node |
 
 ### Examples

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -79,12 +79,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of public keys.
     rpc_module.register_method("blockers", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let blockers = indexes.get_blockers(&pub_key.0)?;
+            let blockers = indexes.get_blockers(&pub_key[0])?;
             let response = json!(blockers);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -330,12 +330,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns a string.
     rpc_module.register_method("latest_name", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let names = indexes.get_latest_name(&pub_key.0)?;
+            let names = indexes.get_latest_name(&pub_key[0])?;
             let response = json!(names);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -148,12 +148,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns a string.
     rpc_module.register_method("latest_self_description", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let description = indexes.get_latest_self_assigned_description(&pub_key.0)?;
+            let description = indexes.get_latest_self_assigned_description(&pub_key[0])?;
             let response = json!(description);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -296,12 +296,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of strings.
     rpc_module.register_method("names", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let names = indexes.get_names(&pub_key.0)?;
+            let names = indexes.get_names(&pub_key[0])?;
             let response = json!(names);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -261,12 +261,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns a string.
     rpc_module.register_method("latest_image", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let image = indexes.get_latest_image(&pub_key.0)?;
+            let image = indexes.get_latest_image(&pub_key[0])?;
             let response = json!(image);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -210,12 +210,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of public keys.
     rpc_module.register_method("friends", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let friends = indexes.get_friends(&pub_key.0)?;
+            let friends = indexes.get_friends(&pub_key[0])?;
             let response = json!(friends);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -364,12 +364,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of public keys.
     rpc_module.register_method("subscribers", move |params: Params, _| {
         task::block_on(async {
-            let channel: Channel = params.parse()?;
+            let channel = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let subscribers = indexes.get_channel_subscribers(&channel.0)?;
+            let subscribers = indexes.get_channel_subscribers(&channel[0])?;
             let response = json!(subscribers);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -381,12 +381,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of channel names.
     rpc_module.register_method("subscriptions", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let subscriptions = indexes.get_channel_subscriptions(&pub_key.0)?;
+            let subscriptions = indexes.get_channel_subscriptions(&pub_key[0])?;
             let response = json!(subscriptions);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -165,12 +165,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of public keys.
     rpc_module.register_method("follows", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let follows = indexes.get_follows(&pub_key.0)?;
+            let follows = indexes.get_follows(&pub_key[0])?;
             let response = json!(follows);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -227,12 +227,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of strings.
     rpc_module.register_method("images", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let images = indexes.get_images(&pub_key.0)?;
+            let images = indexes.get_images(&pub_key[0])?;
             let response = json!(images);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -113,12 +113,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of descriptions.
     rpc_module.register_method("self_descriptions", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let descriptions = indexes.get_self_assigned_descriptions(&pub_key.0)?;
+            let descriptions = indexes.get_self_assigned_descriptions(&pub_key[0])?;
             let response = json!(descriptions);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -8,24 +8,9 @@ use jsonrpsee::server::{logger::Params, RpcModule, ServerBuilder};
 use jsonrpsee::types::error::ErrorObject as JsonRpcError;
 use kuska_ssb::{api::dto::content::TypedMessage, feed::Message, keystore::OwnedIdentity};
 use log::{info, warn};
-use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::{broker::*, error::Error, node::KV_STORE, Result};
-
-/// The name of a channel.
-#[derive(Debug, Deserialize)]
-struct Channel(String);
-
-/// Message reference containing the key (sha256 hash) of a message.
-/// Used to parse the key from the parameters supplied to the `message`
-/// endpoint.
-#[derive(Debug, Deserialize)]
-struct MsgRef(String);
-
-/// The public key (ID) of a peer.
-#[derive(Debug, Deserialize)]
-struct PubKey(String);
 
 /// Register the JSON-RPC server endpoint, define the JSON-RPC methods
 /// and spawn the server.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -96,12 +96,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of descriptions.
     rpc_module.register_method("descriptions", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let descriptions = indexes.get_descriptions(&pub_key.0)?;
+            let descriptions = indexes.get_descriptions(&pub_key[0])?;
             let response = json!(descriptions);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -61,13 +61,13 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     rpc_module.register_method("blocks", move |params: Params, _| {
         task::block_on(async {
             // Parse the parameter containing the public key.
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             // Open the primary KV database for reading.
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let blocks = indexes.get_blocks(&pub_key.0)?;
+            let blocks = indexes.get_blocks(&pub_key[0])?;
             let response = json!(blocks);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -347,12 +347,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns a string.
     rpc_module.register_method("latest_self_name", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let names = indexes.get_latest_self_assigned_name(&pub_key.0)?;
+            let names = indexes.get_latest_self_assigned_name(&pub_key[0])?;
             let response = json!(names);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -313,12 +313,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of strings.
     rpc_module.register_method("self_names", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let names = indexes.get_self_assigned_names(&pub_key.0)?;
+            let names = indexes.get_self_assigned_names(&pub_key[0])?;
             let response = json!(names);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -279,12 +279,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of strings.
     rpc_module.register_method("latest_self_image", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let image = indexes.get_latest_self_assigned_image(&pub_key.0)?;
+            let image = indexes.get_latest_self_assigned_image(&pub_key[0])?;
             let response = json!(image);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -398,13 +398,13 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     rpc_module.register_method("feed", move |params: Params, _| {
         task::block_on(async {
             // Parse the parameter containing the public key.
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             // Open the primary KV database for reading.
             let db = KV_STORE.read().await;
 
             // Retrieve the message value for the requested message.
-            let feed = db.get_feed(&pub_key.0)?;
+            let feed = db.get_feed(&pub_key[0])?;
             let response = json!(feed);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -130,12 +130,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns a string.
     rpc_module.register_method("latest_description", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let description = indexes.get_latest_description(&pub_key.0)?;
+            let description = indexes.get_latest_description(&pub_key[0])?;
             let response = json!(description);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -416,13 +416,13 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     rpc_module.register_method("message", move |params: Params, _| {
         task::block_on(async {
             // Parse the parameter containing the message reference (key).
-            let msg_ref: MsgRef = params.parse()?;
+            let msg_ref = params.parse::<Vec<String>>()?;
 
             // Open the primary KV database for reading.
             let db = KV_STORE.read().await;
 
             // Retrieve the message value for the requested message.
-            let msg_val = db.get_msg_val(&msg_ref.0)?;
+            let msg_val = db.get_msg_val(&msg_ref[0])?;
 
             // Retrieve the message KVT for the requested message using the
             // author and sequence fields from the message value.

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -182,12 +182,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of public keys.
     rpc_module.register_method("followers", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let followers = indexes.get_followers(&pub_key.0)?;
+            let followers = indexes.get_followers(&pub_key[0])?;
             let response = json!(followers);
 
             Ok::<Value, JsonRpcError>(response)

--- a/solar/src/actors/jsonrpc/server.rs
+++ b/solar/src/actors/jsonrpc/server.rs
@@ -244,12 +244,12 @@ pub async fn actor(server_id: OwnedIdentity, server_addr: SocketAddr) -> Result<
     // Returns an array of strings.
     rpc_module.register_method("self_images", move |params: Params, _| {
         task::block_on(async {
-            let pub_key: PubKey = params.parse()?;
+            let pub_key = params.parse::<Vec<String>>()?;
 
             let db = KV_STORE.read().await;
 
             let indexes = &db.indexes.as_ref().ok_or(Error::Indexes)?;
-            let images = indexes.get_self_assigned_images(&pub_key.0)?;
+            let images = indexes.get_self_assigned_images(&pub_key[0])?;
             let response = json!(images);
 
             Ok::<Value, JsonRpcError>(response)


### PR DESCRIPTION
While working on https://github.com/mycognosist/solar/pull/94 I realised the shape of the parameters for many of the methods were not spec-compliant. They must either be an array or a map. I've converted the methods which expected a string to instead expect an array of string; this ends up being a simpler implementation that using maps.