### PR TITLE
fix: Make peer and blob range queries robust to existence of later key prefixes

### DIFF
--- a/solar/src/actors/replication/ebt/manager.rs
+++ b/solar/src/actors/replication/ebt/manager.rs
@@ -510,7 +510,7 @@ impl EbtManager {
         //
         // This indicates that the local peer is acting as the session
         // requester.
-        if self.sent_clocks.get(&connection_id).is_none() {
+        if !self.sent_clocks.contains_key(&connection_id) {
             let local_clock = self.local_clock.to_owned();
             ch_broker
                 .send(BrokerEvent::new(

--- a/solar/src/storage/kv.rs
+++ b/solar/src/storage/kv.rs
@@ -136,8 +136,9 @@ impl KvStorage {
         let mut list = Vec::new();
 
         let db = self.db.as_ref().ok_or(Error::OptionIsNone)?;
-        let scan_key: &[u8] = &[PREFIX_BLOB];
-        for item in db.range(scan_key..) {
+        let scan_key_start: &[u8] = &[PREFIX_BLOB];
+        let scan_key_end: &[u8] = &[PREFIX_BLOB + 1];
+        for item in db.range(scan_key_start..scan_key_end) {
             let (k, v) = item?;
             let blob: BlobStatus = serde_cbor::from_slice(&v)?;
             if !blob.retrieved {

--- a/solar/src/storage/kv.rs
+++ b/solar/src/storage/kv.rs
@@ -226,8 +226,9 @@ impl KvStorage {
         let mut peers = Vec::new();
 
         // Use the generic peer prefix to return an iterator over all peers.
-        let scan_peer_key: &[u8] = &[PREFIX_PEER];
-        for peer in db.range(scan_peer_key..) {
+        let scan_peer_key_start: &[u8] = &[PREFIX_PEER];
+        let scan_peer_key_end: &[u8] = &[PREFIX_PEER + 1];
+        for peer in db.range(scan_peer_key_start..scan_peer_key_end) {
             let (peer_key, _) = peer?;
             // Drop the prefix byte and convert the remaining bytes to
             // a string.


### PR DESCRIPTION
The open range `scan_peer_key..` we were passing into `db.range()` was
returning all keys that start with `4u8` *or higher*.

Simple fix: give `5u8` as the upper bound of the query.

It's worth noting that the same should apply to the blob range queries,
I'll try to make a commit for those next.

One commit with a breaking test, one commit to fix it 🙂

P.S. : @mycognosist hope you're doing okay!
